### PR TITLE
match either ; or # on setting_name

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -31,7 +31,7 @@ module.exports = grammar({
     ),
 
     setting: $ => seq(
-      alias(/[^;|#=\s\[]+/, $.setting_name),
+      alias(/[^;#=\s\[]+/, $.setting_name),
       '=',
       alias(/.+/, $.setting_value),
       '\n',

--- a/grammar.js
+++ b/grammar.js
@@ -31,7 +31,7 @@ module.exports = grammar({
     ),
 
     setting: $ => seq(
-      alias(/[^#=\s\[]+/, $.setting_name),
+      alias(/[^;|#=\s\[]+/, $.setting_name),
       '=',
       alias(/.+/, $.setting_value),
       '\n',


### PR DESCRIPTION
We should either match for # or ; on `setting_name` too, otherwise the highlight breaks  with multiples `;` style comments or when mixing both

Problem:
![image](https://github.com/justinmk/tree-sitter-ini/assets/26150581/9182c1c2-af51-4eb1-ba51-6a61c72bbffd)
![image](https://github.com/justinmk/tree-sitter-ini/assets/26150581/742cb775-c1f3-499d-8a63-e5991dd52c93)
![image](https://github.com/justinmk/tree-sitter-ini/assets/26150581/d45e83da-40a0-4d32-8148-7aa0c1e26582)

Solution:
match `;|#` on setting_name instead of only `#`

