### PR TITLE
Add crates.io upload to release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,8 @@ Steps to perform a release: https://tree-sitter.github.io/tree-sitter/creating-p
    git push
    ```
 6. Tag and release: https://github.com/justinmk/tree-sitter-ini/releases/new
+7. Run
+   ```
+   cargo publish
+   ```
 


### PR DESCRIPTION
An alternative is to do it in the CI on tag or release creation, for instance see https://github.com/tree-sitter/tree-sitter-java/blob/master/.github/workflows/publish.yml. But I can't set it up for you because it requires setting up secrets or attestations.