### PR TITLE
Support for line-continuation using "\" and escaped backslash "\\"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ Notes
 - Section name must appear on a line by itself.
 - Equals sign (=) and semicolon (;) are [reserved characters](https://en.wikipedia.org/wiki/INI_file#Key-value_pairs)
   and cannot appear in the key. Any whitespace surrounding the key is stripped.
-- Comments (`;` or `#`) must start at column 1. Trailing comments are not supported yet. [#13](https://github.com/justinmk/tree-sitter-ini/issues/13)
+- Comments (`;` or `#`) must appear on a line by itself. Trailing comments are not supported yet. [#13](https://github.com/justinmk/tree-sitter-ini/issues/13)
 - Duplicate names are not checked.
-- Line continuations (`\`) are not supported.
+- Line continuations (`\`) are only supported on setting values.
 - `setting_value` includes whitespace. [#3](https://github.com/justinmk/tree-sitter-ini/issues/3).
   Should values exclude surrounding whitespace?
 - [Quoted keys/values](https://en.wikipedia.org/wiki/INI_file#Quoted_values) are not supported yet.
-- Escape sequences are not supported.
+- Escape sequences are supported at minimum.
+    - `\<LF>` (line continuations) and `\\` are supported.
+    - all other sequences are treated literally and have no special meaning.
+    - no highlights, conversions or legimity checks.
 
 Reference
 ---------

--- a/grammar.js
+++ b/grammar.js
@@ -33,7 +33,7 @@ module.exports = grammar({
       '[',
       alias(/[^\[\]]+/, $.text),
       ']',
-      $._eol
+      $._eol,
     ),
 
     setting: $ => seq(
@@ -43,7 +43,7 @@ module.exports = grammar({
       $._eol
     ),
 
-    setting_name: $ => /[^;#=\s\[]+( *[^;#=\s\[])*/,
+    setting_name: $ => /([^;#=\s\[\\]|(\\[^\r\n]))+( +([^;#=\s\[\\]|(\\[^\r\n]))+)*/,
     setting_value: $ => choice(
       $.setting_text,
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -55,15 +55,15 @@ module.exports = grammar({
 
     setting_name: $ => regexp_names("[^\\s\\[\\]\\\\;#=]"),
     setting_value: $ => choice(
-      $.setting_text,
+      alias($.setting_text, $.text),
       seq(
-        optional($.setting_text),
+        optional(alias($.setting_text, $.text)),
         repeat1($.setting_value_cont)
       )
     ),
     setting_value_cont: $ => seq(
       /\\\r?\n/,
-      optional($.setting_text_cont),
+      optional(alias($.setting_text_cont, $.text)),
     ),
 
     // setting text (non-continued) includes:
@@ -78,8 +78,8 @@ module.exports = grammar({
     // - and requires the 1st non-space char not being ";#" (comments)
     // transformed to:
     // 1. consume all leading spaces
-    // 2. match one setting_test char that is also not space or ";#",
-    // 3. match zero or more setting_test char
+    // 2. match one setting_text char that is also not space or ";#",
+    // 3. match zero or more setting_text char
     // NOTE: tree-sitter treats "\s" as " \t\r\n"
     setting_text_cont: $ => /[ \t]*(([^\s\\;#])|(\\[^\r\n]))(([^\r\n\\])|(\\[^\r\n]))*/,
 

--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,1 +1,2 @@
 (section) @fold
+(unnamed_section) @fold

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -60,7 +60,7 @@
           "type": "ALIAS",
           "content": {
             "type": "PATTERN",
-            "value": "[^\\[\\]]+"
+            "value": "(([^\\s\\[\\]\\\\])|(\\\\[^\\r\\n]))+(([ \\t])+(([^\\s\\[\\]\\\\])|(\\\\[^\\r\\n]))+)*"
           },
           "named": true,
           "value": "text"
@@ -106,14 +106,19 @@
     },
     "setting_name": {
       "type": "PATTERN",
-      "value": "[^;#=\\s\\[]+( *[^;#=\\s\\[])*"
+      "value": "(([^\\s\\[\\]\\\\;#=])|(\\\\[^\\r\\n]))+(([ \\t])+(([^\\s\\[\\]\\\\;#=])|(\\\\[^\\r\\n]))+)*"
     },
     "setting_value": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "setting_text"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "setting_text"
+          },
+          "named": true,
+          "value": "text"
         },
         {
           "type": "SEQ",
@@ -122,8 +127,13 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "setting_text"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "setting_text"
+                  },
+                  "named": true,
+                  "value": "text"
                 },
                 {
                   "type": "BLANK"
@@ -145,15 +155,20 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_line_cont"
+          "type": "PATTERN",
+          "value": "\\\\\\r?\\n"
         },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "setting_text"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "setting_text_cont"
+              },
+              "named": true,
+              "value": "text"
             },
             {
               "type": "BLANK"
@@ -163,42 +178,12 @@
       ]
     },
     "setting_text": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "[^\\r\\n]"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_esc_bkslsh"
-          }
-        ]
-      }
+      "type": "PATTERN",
+      "value": "(([^\\r\\n\\\\])|(\\\\[^\\r\\n]))+"
     },
-    "_line_cont": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PREC",
-        "value": 0,
-        "content": {
-          "type": "PATTERN",
-          "value": "\\\\\\r?\\n"
-        }
-      }
-    },
-    "_esc_bkslsh": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PREC",
-        "value": 1,
-        "content": {
-          "type": "STRING",
-          "value": "\\\\"
-        }
-      }
+    "setting_text_cont": {
+      "type": "PATTERN",
+      "value": "[ \\t]*(([^\\s\\\\;#])|(\\\\[^\\r\\n]))(([^\\r\\n\\\\])|(\\\\[^\\r\\n]))*"
     },
     "comment": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6,26 +6,11 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_blank"
-          }
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "setting"
-                  }
-                ]
-              }
+              "type": "SYMBOL",
+              "name": "unnamed_section"
             },
             {
               "type": "BLANK"
@@ -41,30 +26,28 @@
         }
       ]
     },
-    "section": {
-      "type": "PREC_LEFT",
-      "value": 0,
+    "unnamed_section": {
+      "type": "REPEAT1",
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "section_name"
-          },
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "setting"
-                }
-              ]
-            }
-          }
-        ]
+        "type": "SYMBOL",
+        "name": "setting"
       }
+    },
+    "section": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "section_name"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "setting"
+          }
+        }
+      ]
     },
     "section_name": {
       "type": "SEQ",
@@ -87,8 +70,8 @@
           "value": "]"
         },
         {
-          "type": "PATTERN",
-          "value": "\\r?\\n"
+          "type": "SYMBOL",
+          "name": "_eol"
         }
       ]
     },
@@ -96,13 +79,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^;#=\\s\\[]+( *[^;#=\\s\\[])*"
-          },
-          "named": true,
-          "value": "setting_name"
+          "type": "SYMBOL",
+          "name": "setting_name"
         },
         {
           "type": "STRING",
@@ -112,13 +90,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "PATTERN",
-                "value": ".+"
-              },
-              "named": true,
-              "value": "setting_value"
+              "type": "SYMBOL",
+              "name": "setting_value"
             },
             {
               "type": "BLANK"
@@ -126,10 +99,42 @@
           ]
         },
         {
-          "type": "PATTERN",
-          "value": "\\r?\\n"
+          "type": "SYMBOL",
+          "name": "_eol"
         }
       ]
+    },
+    "setting_name": {
+      "type": "PATTERN",
+      "value": "[^;#=\\s\\[]+( *[^;#=\\s\\[])*"
+    },
+    "setting_value": {
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\r\\n]*[^\\r\\n\\\\]"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^\\r\\n]*"
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "\\\\\\r?\\n[^\\r\\n]*"
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     "comment": {
       "type": "SEQ",
@@ -139,27 +144,35 @@
           "value": "[;#]"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^\\r\\n]*"
-          },
-          "named": true,
-          "value": "text"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "PATTERN",
+                "value": "[^\\r\\n]+"
+              },
+              "named": true,
+              "value": "text"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
-          "type": "PATTERN",
-          "value": "\\r?\\n"
+          "type": "SYMBOL",
+          "name": "_eol"
         }
       ]
     },
-    "_blank": {
-      "type": "FIELD",
-      "name": "blank",
-      "content": {
-        "type": "PATTERN",
-        "value": "\\r?\\n"
-      }
+    "_eol": {
+      "type": "PATTERN",
+      "value": "\\r?\\n"
+    },
+    "_space": {
+      "type": "PATTERN",
+      "value": "[ \\t]"
     }
   },
   "extras": [
@@ -169,11 +182,11 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_blank"
+      "name": "_eol"
     },
     {
-      "type": "PATTERN",
-      "value": "[\\t ]"
+      "type": "SYMBOL",
+      "name": "_space"
     }
   ],
   "conflicts": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -109,31 +109,95 @@
       "value": "[^;#=\\s\\[]+( *[^;#=\\s\\[])*"
     },
     "setting_value": {
-      "type": "TOKEN",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "setting_text"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "setting_text"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "setting_value_cont"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "setting_value_cont": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_line_cont"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "setting_text"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "setting_text": {
+      "type": "REPEAT1",
       "content": {
         "type": "CHOICE",
         "members": [
           {
             "type": "PATTERN",
-            "value": "[^\\r\\n]*[^\\r\\n\\\\]"
+            "value": "[^\\r\\n]"
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[^\\r\\n]*"
-              },
-              {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "\\\\\\r?\\n[^\\r\\n]*"
-                }
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_esc_bkslsh"
           }
         ]
+      }
+    },
+    "_line_cont": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 0,
+        "content": {
+          "type": "PATTERN",
+          "value": "\\\\\\r?\\n"
+        }
+      }
+    },
+    "_esc_bkslsh": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "STRING",
+          "value": "\\\\"
+        }
       }
     },
     "comment": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -89,11 +89,6 @@
     }
   },
   {
-    "type": "setting_text",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "setting_value",
     "named": true,
     "fields": {},
@@ -102,11 +97,11 @@
       "required": true,
       "types": [
         {
-          "type": "setting_text",
+          "type": "setting_value_cont",
           "named": true
         },
         {
-          "type": "setting_value_cont",
+          "type": "text",
           "named": true
         }
       ]
@@ -121,7 +116,7 @@
       "required": false,
       "types": [
         {
-          "type": "setting_text",
+          "type": "text",
           "named": true
         }
       ]
@@ -148,10 +143,6 @@
   },
   {
     "type": "[",
-    "named": false
-  },
-  {
-    "type": "\\\\",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -89,6 +89,45 @@
     }
   },
   {
+    "type": "setting_text",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "setting_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "setting_text",
+          "named": true
+        },
+        {
+          "type": "setting_value_cont",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "setting_value_cont",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "setting_text",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "unnamed_section",
     "named": true,
     "fields": {},
@@ -112,15 +151,15 @@
     "named": false
   },
   {
+    "type": "\\\\",
+    "named": false
+  },
+  {
     "type": "]",
     "named": false
   },
   {
     "type": "setting_name",
-    "named": true
-  },
-  {
-    "type": "setting_value",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -6,7 +6,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "text",
@@ -29,7 +29,7 @@
           "named": true
         },
         {
-          "type": "setting",
+          "type": "unnamed_section",
           "named": true
         }
       ]
@@ -83,6 +83,21 @@
         },
         {
           "type": "setting_value",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unnamed_section",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "setting",
           "named": true
         }
       ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,9 +7,9 @@
 #endif
 
 #define LANGUAGE_VERSION 15
-#define STATE_COUNT 37
+#define STATE_COUNT 33
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 27
+#define SYMBOL_COUNT 24
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 13
 #define EXTERNAL_TOKEN_COUNT 0
@@ -25,9 +25,9 @@ enum ts_symbol_identifiers {
   anon_sym_RBRACK = 3,
   anon_sym_EQ = 4,
   sym_setting_name = 5,
-  aux_sym_setting_text_token1 = 6,
-  sym__line_cont = 7,
-  anon_sym_BSLASH_BSLASH = 8,
+  aux_sym_setting_value_cont_token1 = 6,
+  sym_setting_text = 7,
+  sym_setting_text_cont = 8,
   aux_sym_comment_token1 = 9,
   aux_sym_comment_token2 = 10,
   sym__eol = 11,
@@ -39,13 +39,10 @@ enum ts_symbol_identifiers {
   sym_setting = 17,
   sym_setting_value = 18,
   sym_setting_value_cont = 19,
-  sym_setting_text = 20,
-  sym__esc_bkslsh = 21,
-  sym_comment = 22,
-  aux_sym_document_repeat1 = 23,
-  aux_sym_unnamed_section_repeat1 = 24,
-  aux_sym_setting_value_repeat1 = 25,
-  aux_sym_setting_text_repeat1 = 26,
+  sym_comment = 20,
+  aux_sym_document_repeat1 = 21,
+  aux_sym_unnamed_section_repeat1 = 22,
+  aux_sym_setting_value_repeat1 = 23,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -55,9 +52,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RBRACK] = "]",
   [anon_sym_EQ] = "=",
   [sym_setting_name] = "setting_name",
-  [aux_sym_setting_text_token1] = "setting_text_token1",
-  [sym__line_cont] = "_line_cont",
-  [anon_sym_BSLASH_BSLASH] = "\\\\",
+  [aux_sym_setting_value_cont_token1] = "setting_value_cont_token1",
+  [sym_setting_text] = "text",
+  [sym_setting_text_cont] = "text",
   [aux_sym_comment_token1] = "comment_token1",
   [aux_sym_comment_token2] = "text",
   [sym__eol] = "_eol",
@@ -69,13 +66,10 @@ static const char * const ts_symbol_names[] = {
   [sym_setting] = "setting",
   [sym_setting_value] = "setting_value",
   [sym_setting_value_cont] = "setting_value_cont",
-  [sym_setting_text] = "setting_text",
-  [sym__esc_bkslsh] = "_esc_bkslsh",
   [sym_comment] = "comment",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_unnamed_section_repeat1] = "unnamed_section_repeat1",
   [aux_sym_setting_value_repeat1] = "setting_value_repeat1",
-  [aux_sym_setting_text_repeat1] = "setting_text_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -85,9 +79,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [anon_sym_EQ] = anon_sym_EQ,
   [sym_setting_name] = sym_setting_name,
-  [aux_sym_setting_text_token1] = aux_sym_setting_text_token1,
-  [sym__line_cont] = sym__line_cont,
-  [anon_sym_BSLASH_BSLASH] = anon_sym_BSLASH_BSLASH,
+  [aux_sym_setting_value_cont_token1] = aux_sym_setting_value_cont_token1,
+  [sym_setting_text] = aux_sym_section_name_token1,
+  [sym_setting_text_cont] = aux_sym_section_name_token1,
   [aux_sym_comment_token1] = aux_sym_comment_token1,
   [aux_sym_comment_token2] = aux_sym_section_name_token1,
   [sym__eol] = sym__eol,
@@ -99,13 +93,10 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_setting] = sym_setting,
   [sym_setting_value] = sym_setting_value,
   [sym_setting_value_cont] = sym_setting_value_cont,
-  [sym_setting_text] = sym_setting_text,
-  [sym__esc_bkslsh] = sym__esc_bkslsh,
   [sym_comment] = sym_comment,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_unnamed_section_repeat1] = aux_sym_unnamed_section_repeat1,
   [aux_sym_setting_value_repeat1] = aux_sym_setting_value_repeat1,
-  [aux_sym_setting_text_repeat1] = aux_sym_setting_text_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -133,17 +124,17 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [aux_sym_setting_text_token1] = {
+  [aux_sym_setting_value_cont_token1] = {
     .visible = false,
     .named = false,
   },
-  [sym__line_cont] = {
-    .visible = false,
+  [sym_setting_text] = {
+    .visible = true,
     .named = true,
   },
-  [anon_sym_BSLASH_BSLASH] = {
+  [sym_setting_text_cont] = {
     .visible = true,
-    .named = false,
+    .named = true,
   },
   [aux_sym_comment_token1] = {
     .visible = false,
@@ -189,14 +180,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_setting_text] = {
-    .visible = true,
-    .named = true,
-  },
-  [sym__esc_bkslsh] = {
-    .visible = false,
-    .named = true,
-  },
   [sym_comment] = {
     .visible = true,
     .named = true,
@@ -210,10 +193,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_setting_value_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_setting_text_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -261,10 +240,6 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [30] = 30,
   [31] = 31,
   [32] = 32,
-  [33] = 33,
-  [34] = 34,
-  [35] = 35,
-  [36] = 36,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -272,167 +247,213 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(10);
+      if (eof) ADVANCE(17);
       ADVANCE_MAP(
-        '\n', 24,
+        '\n', 29,
         '\r', 1,
-        '=', 15,
-        '[', 11,
-        '\\', 18,
-        ']', 14,
-        '\t', 17,
-        ' ', 17,
-        '#', 17,
-        ';', 17,
+        '=', 21,
+        '[', 18,
+        '\\', 7,
+        ']', 20,
+        '\t', 30,
+        ' ', 30,
+        '#', 26,
+        ';', 26,
       );
-      if (lookahead != 0) ADVANCE(17);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(22);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(24);
+      if (lookahead == '\n') ADVANCE(29);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(24);
+      if (lookahead == '\n') ADVANCE(29);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '\\') ADVANCE(18);
+      if (lookahead == '\\') ADVANCE(8);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(17);
+          lookahead == ' ') ADVANCE(24);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(17);
-      if (lookahead != 0) ADVANCE(17);
+          lookahead == ';') ADVANCE(24);
+      if (lookahead != 0) ADVANCE(24);
       END_STATE();
     case 3:
-      ADVANCE_MAP(
-        '\n', 24,
-        '\r', 1,
-        '\\', 6,
-        ']', 14,
-        '\t', 25,
-        ' ', 25,
-        '#', 21,
-        ';', 21,
-      );
+      if (lookahead == '\n') ADVANCE(29);
+      if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '\\') ADVANCE(9);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(31);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(26);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(25);
       END_STATE();
     case 4:
-      if (lookahead == '\n') ADVANCE(24);
+      if (lookahead == '\n') ADVANCE(29);
       if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '\\') ADVANCE(16);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
+          lookahead == ' ') ADVANCE(30);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(22);
-      if (lookahead != 0) ADVANCE(23);
+          lookahead == ';') ADVANCE(19);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          (lookahead < '[' || ']' < lookahead)) ADVANCE(19);
       END_STATE();
     case 5:
-      if (lookahead == '\n') ADVANCE(19);
+      if (lookahead == '\n') ADVANCE(29);
+      if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(28);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(27);
+      if (lookahead != 0) ADVANCE(28);
       END_STATE();
     case 6:
-      if (lookahead == '\n') ADVANCE(19);
-      if (lookahead == '\r') ADVANCE(5);
+      if (lookahead == '\n') ADVANCE(23);
       END_STATE();
     case 7:
-      if (lookahead == '\n') ADVANCE(13);
-      if (lookahead == '\r') ADVANCE(12);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(13);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(13);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(13);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\r') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(22);
       END_STATE();
     case 8:
-      if (lookahead == ' ') ADVANCE(8);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '#' &&
-          lookahead != ';' &&
-          lookahead != '=' &&
-          lookahead != '[') ADVANCE(16);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\r') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(24);
       END_STATE();
     case 9:
-      if (eof) ADVANCE(10);
-      ADVANCE_MAP(
-        '\n', 24,
-        '\r', 1,
-        '=', 15,
-        '[', 11,
-        '\t', 25,
-        ' ', 25,
-        '#', 21,
-        ';', 21,
-      );
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(16);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\r') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(25);
       END_STATE();
     case 10:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
-      END_STATE();
-    case 11:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 12:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead == '\n') ADVANCE(13);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(13);
-      END_STATE();
-    case 13:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(13);
-      END_STATE();
-    case 14:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 15:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      END_STATE();
-    case 16:
-      ACCEPT_TOKEN(sym_setting_name);
-      if (lookahead == ' ') ADVANCE(8);
+      if (lookahead == '\\') ADVANCE(13);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(10);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != '#' &&
           lookahead != ';' &&
           lookahead != '=' &&
-          lookahead != '[') ADVANCE(16);
+          (lookahead < '[' || ']' < lookahead)) ADVANCE(22);
+      END_STATE();
+    case 11:
+      if (lookahead == '\\') ADVANCE(15);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(11);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '#' &&
+          lookahead != ';') ADVANCE(25);
+      END_STATE();
+    case 12:
+      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(12);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          (lookahead < '[' || ']' < lookahead)) ADVANCE(19);
+      END_STATE();
+    case 13:
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(22);
+      END_STATE();
+    case 14:
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(24);
+      END_STATE();
+    case 15:
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(25);
+      END_STATE();
+    case 16:
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(19);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(aux_sym_setting_text_token1);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(aux_sym_setting_text_token1);
-      if (lookahead == '\n') ADVANCE(19);
-      if (lookahead == '\r') ADVANCE(5);
-      if (lookahead == '\\') ADVANCE(20);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(sym__line_cont);
+      ACCEPT_TOKEN(aux_sym_section_name_token1);
+      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(12);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          (lookahead < '[' || ']' < lookahead)) ADVANCE(19);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(anon_sym_BSLASH_BSLASH);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(aux_sym_comment_token1);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 22:
+      ACCEPT_TOKEN(sym_setting_name);
+      if (lookahead == '\\') ADVANCE(13);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(10);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '#' &&
+          lookahead != ';' &&
+          lookahead != '=' &&
+          (lookahead < '[' || ']' < lookahead)) ADVANCE(22);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(aux_sym_setting_value_cont_token1);
+      END_STATE();
+    case 24:
+      ACCEPT_TOKEN(sym_setting_text);
+      if (lookahead == '\\') ADVANCE(14);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(24);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(sym_setting_text_cont);
+      if (lookahead == '\\') ADVANCE(15);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(25);
+      END_STATE();
+    case 26:
+      ACCEPT_TOKEN(aux_sym_comment_token1);
+      END_STATE();
+    case 27:
       ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(23);
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 23:
+    case 28:
       ACCEPT_TOKEN(aux_sym_comment_token2);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(23);
+          lookahead != '\r') ADVANCE(28);
       END_STATE();
-    case 24:
+    case 29:
       ACCEPT_TOKEN(sym__eol);
       END_STATE();
-    case 25:
+    case 30:
       ACCEPT_TOKEN(sym__space);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(sym__space);
+      if (lookahead == '\\') ADVANCE(15);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(11);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '#' &&
+          lookahead != ';') ADVANCE(25);
       END_STATE();
     default:
       return false;
@@ -441,42 +462,38 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 9},
-  [2] = {.lex_state = 2},
+  [1] = {.lex_state = 0},
+  [2] = {.lex_state = 0},
   [3] = {.lex_state = 2},
-  [4] = {.lex_state = 9},
-  [5] = {.lex_state = 9},
-  [6] = {.lex_state = 9},
-  [7] = {.lex_state = 9},
-  [8] = {.lex_state = 9},
-  [9] = {.lex_state = 9},
-  [10] = {.lex_state = 9},
-  [11] = {.lex_state = 9},
-  [12] = {.lex_state = 2},
-  [13] = {.lex_state = 2},
-  [14] = {.lex_state = 9},
-  [15] = {.lex_state = 9},
-  [16] = {.lex_state = 2},
-  [17] = {.lex_state = 2},
-  [18] = {.lex_state = 9},
-  [19] = {.lex_state = 3},
-  [20] = {.lex_state = 9},
-  [21] = {.lex_state = 3},
-  [22] = {.lex_state = 3},
-  [23] = {.lex_state = 3},
-  [24] = {.lex_state = 9},
-  [25] = {.lex_state = 3},
-  [26] = {.lex_state = 4},
-  [27] = {.lex_state = 9},
-  [28] = {.lex_state = 7},
-  [29] = {.lex_state = 3},
-  [30] = {.lex_state = 9},
-  [31] = {.lex_state = 3},
-  [32] = {.lex_state = 9},
-  [33] = {.lex_state = 9},
-  [34] = {.lex_state = 9},
-  [35] = {(TSStateId)(-1),},
-  [36] = {(TSStateId)(-1),},
+  [4] = {.lex_state = 0},
+  [5] = {.lex_state = 0},
+  [6] = {.lex_state = 0},
+  [7] = {.lex_state = 0},
+  [8] = {.lex_state = 0},
+  [9] = {.lex_state = 0},
+  [10] = {.lex_state = 0},
+  [11] = {.lex_state = 0},
+  [12] = {.lex_state = 0},
+  [13] = {.lex_state = 0},
+  [14] = {.lex_state = 0},
+  [15] = {.lex_state = 0},
+  [16] = {.lex_state = 0},
+  [17] = {.lex_state = 0},
+  [18] = {.lex_state = 0},
+  [19] = {.lex_state = 0},
+  [20] = {.lex_state = 3},
+  [21] = {.lex_state = 0},
+  [22] = {.lex_state = 0},
+  [23] = {.lex_state = 4},
+  [24] = {.lex_state = 0},
+  [25] = {.lex_state = 5},
+  [26] = {.lex_state = 0},
+  [27] = {.lex_state = 0},
+  [28] = {.lex_state = 0},
+  [29] = {.lex_state = 0},
+  [30] = {.lex_state = 0},
+  [31] = {(TSStateId)(-1),},
+  [32] = {(TSStateId)(-1),},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -486,107 +503,131 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
-    [aux_sym_setting_text_token1] = ACTIONS(1),
-    [sym__line_cont] = ACTIONS(1),
-    [anon_sym_BSLASH_BSLASH] = ACTIONS(1),
+    [sym_setting_name] = ACTIONS(1),
+    [aux_sym_setting_value_cont_token1] = ACTIONS(1),
     [aux_sym_comment_token1] = ACTIONS(3),
     [sym__eol] = ACTIONS(5),
-    [sym__space] = ACTIONS(7),
+    [sym__space] = ACTIONS(5),
   },
   [STATE(1)] = {
-    [sym_document] = STATE(27),
-    [sym_unnamed_section] = STATE(6),
-    [sym_section] = STATE(24),
+    [sym_document] = STATE(22),
+    [sym_unnamed_section] = STATE(5),
+    [sym_section] = STATE(19),
     [sym_section_name] = STATE(7),
-    [sym_setting] = STATE(14),
+    [sym_setting] = STATE(11),
     [sym_comment] = STATE(1),
-    [aux_sym_document_repeat1] = STATE(9),
-    [aux_sym_unnamed_section_repeat1] = STATE(8),
-    [ts_builtin_sym_end] = ACTIONS(9),
-    [anon_sym_LBRACK] = ACTIONS(11),
-    [sym_setting_name] = ACTIONS(13),
-    [aux_sym_comment_token1] = ACTIONS(15),
+    [aux_sym_document_repeat1] = STATE(6),
+    [aux_sym_unnamed_section_repeat1] = STATE(4),
+    [ts_builtin_sym_end] = ACTIONS(7),
+    [anon_sym_LBRACK] = ACTIONS(9),
+    [sym_setting_name] = ACTIONS(11),
+    [aux_sym_comment_token1] = ACTIONS(3),
     [sym__eol] = ACTIONS(5),
     [sym__space] = ACTIONS(5),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 13,
+  [0] = 8,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
-      sym__space,
-    ACTIONS(17), 1,
-      aux_sym_setting_text_token1,
-    ACTIONS(19), 1,
-      sym__line_cont,
-    ACTIONS(21), 1,
-      anon_sym_BSLASH_BSLASH,
-    ACTIONS(23), 1,
-      sym__eol,
-    STATE(2), 1,
-      sym_comment,
-    STATE(12), 1,
-      aux_sym_setting_text_repeat1,
-    STATE(16), 1,
-      sym__esc_bkslsh,
-    STATE(19), 1,
-      aux_sym_setting_value_repeat1,
-    STATE(21), 1,
-      sym_setting_text,
-    STATE(31), 1,
-      sym_setting_value_cont,
-    STATE(33), 1,
-      sym_setting_value,
-  [40] = 9,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(7), 1,
-      sym__space,
-    ACTIONS(17), 1,
-      aux_sym_setting_text_token1,
-    ACTIONS(21), 1,
-      anon_sym_BSLASH_BSLASH,
-    STATE(3), 1,
-      sym_comment,
-    STATE(12), 1,
-      aux_sym_setting_text_repeat1,
-    STATE(16), 1,
-      sym__esc_bkslsh,
-    STATE(29), 1,
-      sym_setting_text,
-    ACTIONS(25), 2,
-      sym__line_cont,
-      sym__eol,
-  [69] = 8,
-    ACTIONS(11), 1,
+    ACTIONS(9), 1,
       anon_sym_LBRACK,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(27), 1,
+    ACTIONS(13), 1,
       ts_builtin_sym_end,
-    STATE(4), 1,
+    STATE(2), 1,
       sym_comment,
     STATE(7), 1,
       sym_section_name,
-    STATE(10), 1,
+    STATE(9), 1,
       aux_sym_document_repeat1,
-    STATE(24), 1,
+    STATE(19), 1,
       sym_section,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-  [95] = 7,
-    ACTIONS(13), 1,
-      sym_setting_name,
+  [26] = 9,
     ACTIONS(15), 1,
+      aux_sym_setting_value_cont_token1,
+    ACTIONS(17), 1,
+      sym_setting_text,
+    ACTIONS(19), 1,
       aux_sym_comment_token1,
+    ACTIONS(21), 1,
+      sym__eol,
+    ACTIONS(23), 1,
+      sym__space,
+    STATE(3), 1,
+      sym_comment,
+    STATE(12), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(26), 1,
+      sym_setting_value_cont,
+    STATE(30), 1,
+      sym_setting_value,
+  [54] = 7,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(11), 1,
+      sym_setting_name,
+    STATE(4), 1,
+      sym_comment,
+    STATE(10), 1,
+      aux_sym_unnamed_section_repeat1,
+    STATE(11), 1,
+      sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(25), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+  [78] = 8,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(9), 1,
+      anon_sym_LBRACK,
+    ACTIONS(27), 1,
+      ts_builtin_sym_end,
+    STATE(2), 1,
+      aux_sym_document_repeat1,
     STATE(5), 1,
       sym_comment,
-    STATE(11), 1,
+    STATE(7), 1,
+      sym_section_name,
+    STATE(19), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [104] = 8,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(9), 1,
+      anon_sym_LBRACK,
+    ACTIONS(27), 1,
+      ts_builtin_sym_end,
+    STATE(6), 1,
+      sym_comment,
+    STATE(7), 1,
+      sym_section_name,
+    STATE(9), 1,
+      aux_sym_document_repeat1,
+    STATE(19), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [130] = 7,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(11), 1,
+      sym_setting_name,
+    STATE(7), 1,
+      sym_comment,
+    STATE(8), 1,
       aux_sym_unnamed_section_repeat1,
-    STATE(14), 1,
+    STATE(11), 1,
       sym_setting,
     ACTIONS(5), 2,
       sym__eol,
@@ -594,486 +635,372 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(29), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-  [119] = 8,
+  [154] = 7,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
     ACTIONS(11), 1,
-      anon_sym_LBRACK,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(31), 1,
-      ts_builtin_sym_end,
-    STATE(4), 1,
-      aux_sym_document_repeat1,
-    STATE(6), 1,
-      sym_comment,
-    STATE(7), 1,
-      sym_section_name,
-    STATE(24), 1,
-      sym_section,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [145] = 7,
-    ACTIONS(13), 1,
       sym_setting_name,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    STATE(5), 1,
-      aux_sym_unnamed_section_repeat1,
-    STATE(7), 1,
-      sym_comment,
-    STATE(14), 1,
-      sym_setting,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(33), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-  [169] = 7,
-    ACTIONS(13), 1,
-      sym_setting_name,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
     STATE(8), 1,
       sym_comment,
-    STATE(11), 1,
+    STATE(10), 1,
       aux_sym_unnamed_section_repeat1,
-    STATE(14), 1,
+    STATE(11), 1,
       sym_setting,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(35), 2,
+    ACTIONS(31), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-  [193] = 8,
-    ACTIONS(11), 1,
-      anon_sym_LBRACK,
-    ACTIONS(15), 1,
+  [178] = 7,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(31), 1,
+    ACTIONS(33), 1,
       ts_builtin_sym_end,
+    ACTIONS(35), 1,
+      anon_sym_LBRACK,
     STATE(7), 1,
       sym_section_name,
-    STATE(9), 1,
+    STATE(19), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    STATE(9), 2,
       sym_comment,
-    STATE(10), 1,
       aux_sym_document_repeat1,
-    STATE(24), 1,
-      sym_section,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [219] = 7,
-    ACTIONS(15), 1,
+  [202] = 6,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(37), 1,
-      ts_builtin_sym_end,
-    ACTIONS(39), 1,
-      anon_sym_LBRACK,
-    STATE(7), 1,
-      sym_section_name,
-    STATE(24), 1,
-      sym_section,
+    ACTIONS(40), 1,
+      sym_setting_name,
+    STATE(11), 1,
+      sym_setting,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
+    ACTIONS(38), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
     STATE(10), 2,
       sym_comment,
-      aux_sym_document_repeat1,
-  [243] = 6,
-    ACTIONS(15), 1,
+      aux_sym_unnamed_section_repeat1,
+  [224] = 4,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(44), 1,
-      sym_setting_name,
-    STATE(14), 1,
-      sym_setting,
+    STATE(11), 1,
+      sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(42), 2,
+    ACTIONS(43), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-    STATE(11), 2,
-      sym_comment,
-      aux_sym_unnamed_section_repeat1,
-  [265] = 8,
+      sym_setting_name,
+  [240] = 7,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
+    ACTIONS(5), 1,
       sym__space,
-    ACTIONS(17), 1,
-      aux_sym_setting_text_token1,
-    ACTIONS(21), 1,
-      anon_sym_BSLASH_BSLASH,
+    ACTIONS(15), 1,
+      aux_sym_setting_value_cont_token1,
+    ACTIONS(45), 1,
+      sym__eol,
     STATE(12), 1,
       sym_comment,
-    STATE(13), 1,
-      aux_sym_setting_text_repeat1,
-    STATE(16), 1,
-      sym__esc_bkslsh,
-    ACTIONS(47), 2,
-      sym__line_cont,
-      sym__eol,
-  [291] = 7,
+    STATE(18), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(26), 1,
+      sym_setting_value_cont,
+  [262] = 4,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
-      sym__space,
-    ACTIONS(49), 1,
-      aux_sym_setting_text_token1,
-    ACTIONS(54), 1,
-      anon_sym_BSLASH_BSLASH,
-    STATE(16), 1,
-      sym__esc_bkslsh,
-    ACTIONS(52), 2,
-      sym__line_cont,
-      sym__eol,
-    STATE(13), 2,
+    STATE(13), 1,
       sym_comment,
-      aux_sym_setting_text_repeat1,
-  [315] = 4,
-    ACTIONS(15), 1,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(47), 3,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+      sym_setting_name,
+  [278] = 4,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
     STATE(14), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(57), 3,
+    ACTIONS(49), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
       sym_setting_name,
-  [331] = 4,
-    ACTIONS(15), 1,
+  [294] = 7,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_setting_value_cont_token1,
+    ACTIONS(45), 1,
+      sym__eol,
     STATE(15), 1,
       sym_comment,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(59), 3,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      sym_setting_name,
-  [347] = 5,
+    STATE(16), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(26), 1,
+      sym_setting_value_cont,
+  [316] = 7,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
+    ACTIONS(5), 1,
       sym__space,
-    ACTIONS(61), 1,
-      aux_sym_setting_text_token1,
+    ACTIONS(15), 1,
+      aux_sym_setting_value_cont_token1,
+    ACTIONS(51), 1,
+      sym__eol,
     STATE(16), 1,
       sym_comment,
-    ACTIONS(63), 3,
-      sym__line_cont,
-      anon_sym_BSLASH_BSLASH,
-      sym__eol,
-  [365] = 5,
+    STATE(18), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(26), 1,
+      sym_setting_value_cont,
+  [338] = 4,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
-      sym__space,
-    ACTIONS(65), 1,
-      aux_sym_setting_text_token1,
     STATE(17), 1,
       sym_comment,
-    ACTIONS(67), 3,
-      sym__line_cont,
-      anon_sym_BSLASH_BSLASH,
-      sym__eol,
-  [383] = 4,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    STATE(18), 1,
-      sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(69), 3,
+    ACTIONS(53), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
       sym_setting_name,
-  [399] = 7,
+  [354] = 6,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
     ACTIONS(5), 1,
       sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(19), 1,
-      sym__line_cont,
-    ACTIONS(71), 1,
+    ACTIONS(55), 1,
+      aux_sym_setting_value_cont_token1,
+    ACTIONS(58), 1,
       sym__eol,
+    STATE(26), 1,
+      sym_setting_value_cont,
+    STATE(18), 2,
+      sym_comment,
+      aux_sym_setting_value_repeat1,
+  [374] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
     STATE(19), 1,
       sym_comment,
-    STATE(23), 1,
-      aux_sym_setting_value_repeat1,
-    STATE(31), 1,
-      sym_setting_value_cont,
-  [421] = 4,
-    ACTIONS(15), 1,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(60), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+  [389] = 5,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
+    ACTIONS(23), 1,
+      sym__space,
+    ACTIONS(64), 1,
+      sym_setting_text_cont,
     STATE(20), 1,
+      sym_comment,
+    ACTIONS(62), 2,
+      aux_sym_setting_value_cont_token1,
+      sym__eol,
+  [406] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(66), 1,
+      anon_sym_EQ,
+    STATE(21), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(73), 3,
+  [420] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(68), 1,
       ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      sym_setting_name,
-  [437] = 7,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(19), 1,
-      sym__line_cont,
-    ACTIONS(71), 1,
-      sym__eol,
-    STATE(21), 1,
-      sym_comment,
-    STATE(22), 1,
-      aux_sym_setting_value_repeat1,
-    STATE(31), 1,
-      sym_setting_value_cont,
-  [459] = 7,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(19), 1,
-      sym__line_cont,
-    ACTIONS(75), 1,
-      sym__eol,
     STATE(22), 1,
       sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [434] = 4,
+    ACTIONS(19), 1,
+      aux_sym_comment_token1,
+    ACTIONS(70), 1,
+      aux_sym_section_name_token1,
     STATE(23), 1,
-      aux_sym_setting_value_repeat1,
-    STATE(31), 1,
-      sym_setting_value_cont,
-  [481] = 6,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(77), 1,
-      sym__line_cont,
-    ACTIONS(80), 1,
-      sym__eol,
-    STATE(31), 1,
-      sym_setting_value_cont,
-    STATE(23), 2,
       sym_comment,
-      aux_sym_setting_value_repeat1,
-  [501] = 4,
-    ACTIONS(15), 1,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [448] = 4,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
+    ACTIONS(72), 1,
+      anon_sym_RBRACK,
     STATE(24), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(82), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-  [516] = 4,
-    ACTIONS(15), 1,
+  [462] = 5,
+    ACTIONS(19), 1,
       aux_sym_comment_token1,
-    ACTIONS(84), 1,
-      anon_sym_RBRACK,
+    ACTIONS(23), 1,
+      sym__space,
+    ACTIONS(74), 1,
+      aux_sym_comment_token2,
+    ACTIONS(76), 1,
+      sym__eol,
     STATE(25), 1,
       sym_comment,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [530] = 5,
+  [478] = 4,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(7), 1,
+    ACTIONS(5), 1,
       sym__space,
-    ACTIONS(86), 1,
-      aux_sym_comment_token2,
-    ACTIONS(88), 1,
-      sym__eol,
     STATE(26), 1,
       sym_comment,
-  [546] = 4,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(90), 1,
-      ts_builtin_sym_end,
-    STATE(27), 1,
-      sym_comment,
-    ACTIONS(5), 2,
+    ACTIONS(78), 2,
+      aux_sym_setting_value_cont_token1,
       sym__eol,
-      sym__space,
-  [560] = 4,
+  [492] = 4,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(92), 1,
-      aux_sym_section_name_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    STATE(27), 1,
+      sym_comment,
+    ACTIONS(80), 2,
+      aux_sym_setting_value_cont_token1,
+      sym__eol,
+  [506] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(82), 1,
+      sym__eol,
     STATE(28), 1,
       sym_comment,
-    ACTIONS(7), 2,
-      sym__eol,
-      sym__space,
-  [574] = 4,
+  [519] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
     ACTIONS(5), 1,
       sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
+    ACTIONS(84), 1,
+      sym__eol,
     STATE(29), 1,
       sym_comment,
-    ACTIONS(94), 2,
-      sym__line_cont,
-      sym__eol,
-  [588] = 4,
-    ACTIONS(15), 1,
+  [532] = 4,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(96), 1,
-      anon_sym_EQ,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(86), 1,
+      sym__eol,
     STATE(30), 1,
       sym_comment,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [602] = 4,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    STATE(31), 1,
-      sym_comment,
-    ACTIONS(98), 2,
-      sym__line_cont,
-      sym__eol,
-  [616] = 4,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(100), 1,
-      sym__eol,
-    STATE(32), 1,
-      sym_comment,
-  [629] = 4,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(102), 1,
-      sym__eol,
-    STATE(33), 1,
-      sym_comment,
-  [642] = 4,
-    ACTIONS(5), 1,
-      sym__space,
-    ACTIONS(15), 1,
-      aux_sym_comment_token1,
-    ACTIONS(104), 1,
-      sym__eol,
-    STATE(34), 1,
-      sym_comment,
-  [655] = 1,
-    ACTIONS(106), 1,
+  [545] = 1,
+    ACTIONS(88), 1,
       ts_builtin_sym_end,
-  [659] = 1,
-    ACTIONS(108), 1,
+  [549] = 1,
+    ACTIONS(90), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 40,
-  [SMALL_STATE(4)] = 69,
-  [SMALL_STATE(5)] = 95,
-  [SMALL_STATE(6)] = 119,
-  [SMALL_STATE(7)] = 145,
-  [SMALL_STATE(8)] = 169,
-  [SMALL_STATE(9)] = 193,
-  [SMALL_STATE(10)] = 219,
-  [SMALL_STATE(11)] = 243,
-  [SMALL_STATE(12)] = 265,
-  [SMALL_STATE(13)] = 291,
-  [SMALL_STATE(14)] = 315,
-  [SMALL_STATE(15)] = 331,
-  [SMALL_STATE(16)] = 347,
-  [SMALL_STATE(17)] = 365,
-  [SMALL_STATE(18)] = 383,
-  [SMALL_STATE(19)] = 399,
-  [SMALL_STATE(20)] = 421,
-  [SMALL_STATE(21)] = 437,
-  [SMALL_STATE(22)] = 459,
-  [SMALL_STATE(23)] = 481,
-  [SMALL_STATE(24)] = 501,
-  [SMALL_STATE(25)] = 516,
-  [SMALL_STATE(26)] = 530,
-  [SMALL_STATE(27)] = 546,
-  [SMALL_STATE(28)] = 560,
-  [SMALL_STATE(29)] = 574,
-  [SMALL_STATE(30)] = 588,
-  [SMALL_STATE(31)] = 602,
-  [SMALL_STATE(32)] = 616,
-  [SMALL_STATE(33)] = 629,
-  [SMALL_STATE(34)] = 642,
-  [SMALL_STATE(35)] = 655,
-  [SMALL_STATE(36)] = 659,
+  [SMALL_STATE(3)] = 26,
+  [SMALL_STATE(4)] = 54,
+  [SMALL_STATE(5)] = 78,
+  [SMALL_STATE(6)] = 104,
+  [SMALL_STATE(7)] = 130,
+  [SMALL_STATE(8)] = 154,
+  [SMALL_STATE(9)] = 178,
+  [SMALL_STATE(10)] = 202,
+  [SMALL_STATE(11)] = 224,
+  [SMALL_STATE(12)] = 240,
+  [SMALL_STATE(13)] = 262,
+  [SMALL_STATE(14)] = 278,
+  [SMALL_STATE(15)] = 294,
+  [SMALL_STATE(16)] = 316,
+  [SMALL_STATE(17)] = 338,
+  [SMALL_STATE(18)] = 354,
+  [SMALL_STATE(19)] = 374,
+  [SMALL_STATE(20)] = 389,
+  [SMALL_STATE(21)] = 406,
+  [SMALL_STATE(22)] = 420,
+  [SMALL_STATE(23)] = 434,
+  [SMALL_STATE(24)] = 448,
+  [SMALL_STATE(25)] = 462,
+  [SMALL_STATE(26)] = 478,
+  [SMALL_STATE(27)] = 492,
+  [SMALL_STATE(28)] = 506,
+  [SMALL_STATE(29)] = 519,
+  [SMALL_STATE(30)] = 532,
+  [SMALL_STATE(31)] = 545,
+  [SMALL_STATE(32)] = 549,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 1, 0, 0),
-  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unnamed_section, 1, 0, 0),
-  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
-  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0),
-  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
-  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_text, 1, 0, 0),
-  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
-  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0),
-  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 1, 0, 0),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
-  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_setting_text_repeat1, 1, 0, 0),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 1, 0, 0),
-  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__esc_bkslsh, 1, 0, 0),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__esc_bkslsh, 1, 0, 0),
-  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 1, 0, 0),
-  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 2, 0, 0),
-  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
-  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1, 0, 0),
-  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [90] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 2, 0, 0),
-  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 1, 0, 0),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
-  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
+  [7] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unnamed_section, 1, 0, 0),
+  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
+  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
+  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [35] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(23),
+  [38] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
+  [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 1, 0, 0),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 1, 0, 0),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 2, 0, 0),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
+  [55] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0), SHIFT_REPEAT(20),
+  [58] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1, 0, 0),
+  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 1, 0, 0),
+  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [68] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [74] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 1, 0, 0),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 2, 0, 0),
+  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [86] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
 };
 
 #ifdef __cplusplus

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,37 +7,37 @@
 #endif
 
 #define LANGUAGE_VERSION 15
-#define STATE_COUNT 30
-#define LARGE_STATE_COUNT 5
+#define STATE_COUNT 26
+#define LARGE_STATE_COUNT 2
 #define SYMBOL_COUNT 19
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 10
+#define TOKEN_COUNT 11
 #define EXTERNAL_TOKEN_COUNT 0
-#define FIELD_COUNT 1
+#define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
 #define MAX_RESERVED_WORD_SET_SIZE 0
-#define PRODUCTION_ID_COUNT 2
+#define PRODUCTION_ID_COUNT 1
 #define SUPERTYPE_COUNT 0
 
 enum ts_symbol_identifiers {
   anon_sym_LBRACK = 1,
   aux_sym_section_name_token1 = 2,
   anon_sym_RBRACK = 3,
-  aux_sym_section_name_token2 = 4,
-  aux_sym_setting_token1 = 5,
-  anon_sym_EQ = 6,
-  aux_sym_setting_token2 = 7,
-  aux_sym_comment_token1 = 8,
-  aux_sym_comment_token2 = 9,
-  sym_document = 10,
-  sym_section = 11,
-  sym_section_name = 12,
-  sym_setting = 13,
-  sym_comment = 14,
-  sym__blank = 15,
-  aux_sym_document_repeat1 = 16,
-  aux_sym_document_repeat2 = 17,
-  aux_sym_document_repeat3 = 18,
+  anon_sym_EQ = 4,
+  sym_setting_name = 5,
+  sym_setting_value = 6,
+  aux_sym_comment_token1 = 7,
+  aux_sym_comment_token2 = 8,
+  sym__eol = 9,
+  sym__space = 10,
+  sym_document = 11,
+  sym_unnamed_section = 12,
+  sym_section = 13,
+  sym_section_name = 14,
+  sym_setting = 15,
+  sym_comment = 16,
+  aux_sym_document_repeat1 = 17,
+  aux_sym_unnamed_section_repeat1 = 18,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -45,21 +45,21 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACK] = "[",
   [aux_sym_section_name_token1] = "text",
   [anon_sym_RBRACK] = "]",
-  [aux_sym_section_name_token2] = "section_name_token2",
-  [aux_sym_setting_token1] = "setting_name",
   [anon_sym_EQ] = "=",
-  [aux_sym_setting_token2] = "setting_value",
+  [sym_setting_name] = "setting_name",
+  [sym_setting_value] = "setting_value",
   [aux_sym_comment_token1] = "comment_token1",
   [aux_sym_comment_token2] = "text",
+  [sym__eol] = "_eol",
+  [sym__space] = "_space",
   [sym_document] = "document",
+  [sym_unnamed_section] = "unnamed_section",
   [sym_section] = "section",
   [sym_section_name] = "section_name",
   [sym_setting] = "setting",
   [sym_comment] = "comment",
-  [sym__blank] = "_blank",
   [aux_sym_document_repeat1] = "document_repeat1",
-  [aux_sym_document_repeat2] = "document_repeat2",
-  [aux_sym_document_repeat3] = "document_repeat3",
+  [aux_sym_unnamed_section_repeat1] = "unnamed_section_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -67,21 +67,21 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACK] = anon_sym_LBRACK,
   [aux_sym_section_name_token1] = aux_sym_section_name_token1,
   [anon_sym_RBRACK] = anon_sym_RBRACK,
-  [aux_sym_section_name_token2] = aux_sym_section_name_token2,
-  [aux_sym_setting_token1] = aux_sym_setting_token1,
   [anon_sym_EQ] = anon_sym_EQ,
-  [aux_sym_setting_token2] = aux_sym_setting_token2,
+  [sym_setting_name] = sym_setting_name,
+  [sym_setting_value] = sym_setting_value,
   [aux_sym_comment_token1] = aux_sym_comment_token1,
   [aux_sym_comment_token2] = aux_sym_section_name_token1,
+  [sym__eol] = sym__eol,
+  [sym__space] = sym__space,
   [sym_document] = sym_document,
+  [sym_unnamed_section] = sym_unnamed_section,
   [sym_section] = sym_section,
   [sym_section_name] = sym_section_name,
   [sym_setting] = sym_setting,
   [sym_comment] = sym_comment,
-  [sym__blank] = sym__blank,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
-  [aux_sym_document_repeat2] = aux_sym_document_repeat2,
-  [aux_sym_document_repeat3] = aux_sym_document_repeat3,
+  [aux_sym_unnamed_section_repeat1] = aux_sym_unnamed_section_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -101,19 +101,15 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_section_name_token2] = {
-    .visible = false,
-    .named = false,
-  },
-  [aux_sym_setting_token1] = {
-    .visible = true,
-    .named = true,
-  },
   [anon_sym_EQ] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_setting_token2] = {
+  [sym_setting_name] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_setting_value] = {
     .visible = true,
     .named = true,
   },
@@ -125,7 +121,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym__eol] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__space] = {
+    .visible = false,
+    .named = true,
+  },
   [sym_document] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_unnamed_section] = {
     .visible = true,
     .named = true,
   },
@@ -145,40 +153,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym__blank] = {
-    .visible = false,
-    .named = true,
-  },
   [aux_sym_document_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_document_repeat2] = {
+  [aux_sym_unnamed_section_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_document_repeat3] = {
-    .visible = false,
-    .named = false,
-  },
-};
-
-enum ts_field_identifiers {
-  field_blank = 1,
-};
-
-static const char * const ts_field_names[] = {
-  [0] = NULL,
-  [field_blank] = "blank",
-};
-
-static const TSMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
-  [1] = {.index = 0, .length = 1},
-};
-
-static const TSFieldMapEntry ts_field_map_entries[] = {
-  [0] =
-    {field_blank, 0},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
@@ -216,10 +198,6 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [23] = 23,
   [24] = 24,
   [25] = 25,
-  [26] = 26,
-  [27] = 27,
-  [28] = 17,
-  [29] = 29,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -227,150 +205,145 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(6);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '=') ADVANCE(14);
-      if (lookahead == '[') ADVANCE(7);
-      if (lookahead == ']') ADVANCE(11);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(0);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(18);
+      if (eof) ADVANCE(9);
+      ADVANCE_MAP(
+        '\n', 22,
+        '\r', 1,
+        '=', 14,
+        '[', 10,
+        ']', 13,
+        '\t', 23,
+        ' ', 23,
+        '#', 19,
+        ';', 19,
+      );
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(12);
+      if (lookahead == '\n') ADVANCE(22);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '\\') ADVANCE(6);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(16);
+          lookahead == ' ') ADVANCE(17);
       if (lookahead == '#' ||
           lookahead == ';') ADVANCE(17);
       if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(10);
-      if (lookahead == '\r') ADVANCE(9);
+      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\r') ADVANCE(1);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(8);
+          lookahead == ' ') ADVANCE(21);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(10);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(10);
+          lookahead == ';') ADVANCE(20);
+      if (lookahead != 0) ADVANCE(21);
       END_STATE();
     case 4:
-      if (lookahead == ' ') ADVANCE(4);
+      if (lookahead == '\n') ADVANCE(12);
+      if (lookahead == '\r') ADVANCE(11);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(12);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(12);
       if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '#' &&
-          lookahead != ';' &&
-          lookahead != '=' &&
-          lookahead != '[') ADVANCE(13);
+          lookahead != '[' &&
+          lookahead != ']') ADVANCE(12);
       END_STATE();
     case 5:
-      if (eof) ADVANCE(6);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '[') ADVANCE(7);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(5);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(18);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '=') ADVANCE(13);
+      if (lookahead == '\n') ADVANCE(18);
       END_STATE();
     case 6:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == '\n') ADVANCE(18);
+      if (lookahead == '\r') ADVANCE(5);
+      if (lookahead == '\\') ADVANCE(6);
+      if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 7:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 8:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead == '\n') ADVANCE(10);
-      if (lookahead == '\r') ADVANCE(9);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(8);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(10);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(10);
-      END_STATE();
-    case 9:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead == '\n') ADVANCE(10);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(10);
-      END_STATE();
-    case 10:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(10);
-      END_STATE();
-    case 11:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 12:
-      ACCEPT_TOKEN(aux_sym_section_name_token2);
-      END_STATE();
-    case 13:
-      ACCEPT_TOKEN(aux_sym_setting_token1);
-      if (lookahead == ' ') ADVANCE(4);
+      if (lookahead == ' ') ADVANCE(7);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != '#' &&
           lookahead != ';' &&
           lookahead != '=' &&
-          lookahead != '[') ADVANCE(13);
+          lookahead != '[') ADVANCE(15);
+      END_STATE();
+    case 8:
+      if (eof) ADVANCE(9);
+      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\r') ADVANCE(1);
+      if (lookahead == '[') ADVANCE(10);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(19);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '=') ADVANCE(15);
+      END_STATE();
+    case 9:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 10:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 11:
+      ACCEPT_TOKEN(aux_sym_section_name_token1);
+      if (lookahead == '\n') ADVANCE(12);
+      if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']') ADVANCE(12);
+      END_STATE();
+    case 12:
+      ACCEPT_TOKEN(aux_sym_section_name_token1);
+      if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']') ADVANCE(12);
+      END_STATE();
+    case 13:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 14:
       ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 15:
-      ACCEPT_TOKEN(aux_sym_setting_token2);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead != 0) ADVANCE(17);
+      ACCEPT_TOKEN(sym_setting_name);
+      if (lookahead == ' ') ADVANCE(7);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '#' &&
+          lookahead != ';' &&
+          lookahead != '=' &&
+          lookahead != '[') ADVANCE(15);
       END_STATE();
     case 16:
-      ACCEPT_TOKEN(aux_sym_setting_token2);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(16);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(17);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(17);
+      ACCEPT_TOKEN(sym_setting_value);
+      if (lookahead == '\n') ADVANCE(18);
+      if (lookahead == '\r') ADVANCE(5);
+      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead != 0) ADVANCE(18);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(aux_sym_setting_token2);
+      ACCEPT_TOKEN(sym_setting_value);
+      if (lookahead == '\\') ADVANCE(6);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(17);
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(17);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(aux_sym_comment_token1);
+      ACCEPT_TOKEN(sym_setting_value);
+      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '\r') ADVANCE(18);
       END_STATE();
     case 19:
       ACCEPT_TOKEN(aux_sym_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(21);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(aux_sym_comment_token2);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(20);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(19);
+      ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead != 0 &&
-          lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r') ADVANCE(21);
       END_STATE();
@@ -380,6 +353,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '\r') ADVANCE(21);
       END_STATE();
+    case 22:
+      ACCEPT_TOKEN(sym__eol);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(sym__space);
+      END_STATE();
     default:
       return false;
   }
@@ -387,473 +366,421 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 5},
-  [2] = {.lex_state = 5},
-  [3] = {.lex_state = 5},
-  [4] = {.lex_state = 5},
-  [5] = {.lex_state = 5},
-  [6] = {.lex_state = 0},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 5},
+  [1] = {.lex_state = 8},
+  [2] = {.lex_state = 8},
+  [3] = {.lex_state = 0},
+  [4] = {.lex_state = 8},
+  [5] = {.lex_state = 0},
+  [6] = {.lex_state = 8},
+  [7] = {.lex_state = 8},
+  [8] = {.lex_state = 0},
   [9] = {.lex_state = 0},
-  [10] = {.lex_state = 5},
-  [11] = {.lex_state = 0},
-  [12] = {.lex_state = 5},
-  [13] = {.lex_state = 5},
-  [14] = {.lex_state = 5},
-  [15] = {.lex_state = 5},
-  [16] = {.lex_state = 5},
-  [17] = {.lex_state = 5},
+  [10] = {.lex_state = 8},
+  [11] = {.lex_state = 8},
+  [12] = {.lex_state = 8},
+  [13] = {.lex_state = 8},
+  [14] = {.lex_state = 0},
+  [15] = {.lex_state = 4},
+  [16] = {.lex_state = 0},
+  [17] = {.lex_state = 3},
   [18] = {.lex_state = 0},
-  [19] = {.lex_state = 3},
+  [19] = {.lex_state = 2},
   [20] = {.lex_state = 0},
   [21] = {.lex_state = 0},
-  [22] = {.lex_state = 20},
+  [22] = {.lex_state = 0},
   [23] = {.lex_state = 0},
-  [24] = {.lex_state = 2},
-  [25] = {.lex_state = 0},
-  [26] = {.lex_state = 0},
-  [27] = {.lex_state = 0},
-  [28] = {(TSStateId)(-1),},
-  [29] = {(TSStateId)(-1),},
+  [24] = {(TSStateId)(-1),},
+  [25] = {(TSStateId)(-1),},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [STATE(0)] = {
     [sym_comment] = STATE(0),
-    [sym__blank] = STATE(0),
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
-    [aux_sym_section_name_token2] = ACTIONS(3),
     [anon_sym_EQ] = ACTIONS(1),
-    [aux_sym_comment_token1] = ACTIONS(5),
+    [aux_sym_comment_token1] = ACTIONS(3),
+    [sym__eol] = ACTIONS(5),
+    [sym__space] = ACTIONS(5),
   },
   [STATE(1)] = {
-    [sym_document] = STATE(20),
-    [sym_section] = STATE(18),
-    [sym_section_name] = STATE(5),
-    [sym_setting] = STATE(13),
+    [sym_document] = STATE(18),
+    [sym_unnamed_section] = STATE(3),
+    [sym_section] = STATE(14),
+    [sym_section_name] = STATE(4),
+    [sym_setting] = STATE(10),
     [sym_comment] = STATE(1),
-    [sym__blank] = STATE(1),
-    [aux_sym_document_repeat1] = STATE(2),
-    [aux_sym_document_repeat2] = STATE(3),
-    [aux_sym_document_repeat3] = STATE(6),
+    [aux_sym_document_repeat1] = STATE(5),
+    [aux_sym_unnamed_section_repeat1] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(7),
     [anon_sym_LBRACK] = ACTIONS(9),
-    [aux_sym_section_name_token2] = ACTIONS(11),
-    [aux_sym_setting_token1] = ACTIONS(13),
-    [aux_sym_comment_token1] = ACTIONS(5),
-  },
-  [STATE(2)] = {
-    [sym_section] = STATE(18),
-    [sym_section_name] = STATE(5),
-    [sym_setting] = STATE(13),
-    [sym_comment] = STATE(2),
-    [sym__blank] = STATE(2),
-    [aux_sym_document_repeat1] = STATE(12),
-    [aux_sym_document_repeat2] = STATE(4),
-    [aux_sym_document_repeat3] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(15),
-    [anon_sym_LBRACK] = ACTIONS(9),
-    [aux_sym_section_name_token2] = ACTIONS(11),
-    [aux_sym_setting_token1] = ACTIONS(13),
-    [aux_sym_comment_token1] = ACTIONS(5),
-  },
-  [STATE(3)] = {
-    [sym_section] = STATE(18),
-    [sym_section_name] = STATE(5),
-    [sym_setting] = STATE(13),
-    [sym_comment] = STATE(3),
-    [sym__blank] = STATE(3),
-    [aux_sym_document_repeat2] = STATE(10),
-    [aux_sym_document_repeat3] = STATE(7),
-    [ts_builtin_sym_end] = ACTIONS(15),
-    [anon_sym_LBRACK] = ACTIONS(9),
-    [aux_sym_section_name_token2] = ACTIONS(3),
-    [aux_sym_setting_token1] = ACTIONS(13),
-    [aux_sym_comment_token1] = ACTIONS(5),
-  },
-  [STATE(4)] = {
-    [sym_section] = STATE(18),
-    [sym_section_name] = STATE(5),
-    [sym_setting] = STATE(13),
-    [sym_comment] = STATE(4),
-    [sym__blank] = STATE(4),
-    [aux_sym_document_repeat2] = STATE(10),
-    [aux_sym_document_repeat3] = STATE(11),
-    [ts_builtin_sym_end] = ACTIONS(17),
-    [anon_sym_LBRACK] = ACTIONS(9),
-    [aux_sym_section_name_token2] = ACTIONS(3),
-    [aux_sym_setting_token1] = ACTIONS(13),
-    [aux_sym_comment_token1] = ACTIONS(5),
+    [sym_setting_name] = ACTIONS(11),
+    [aux_sym_comment_token1] = ACTIONS(3),
+    [sym__eol] = ACTIONS(5),
+    [sym__space] = ACTIONS(5),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
   [0] = 7,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    ACTIONS(13), 1,
-      aux_sym_setting_token1,
-    STATE(8), 1,
-      aux_sym_document_repeat2,
-    STATE(13), 1,
+    ACTIONS(11), 1,
+      sym_setting_name,
+    STATE(2), 1,
+      sym_comment,
+    STATE(7), 1,
+      aux_sym_unnamed_section_repeat1,
+    STATE(10), 1,
       sym_setting,
-    ACTIONS(19), 2,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(13), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-    STATE(5), 2,
-      sym_comment,
-      sym__blank,
   [24] = 8,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
     ACTIONS(9), 1,
       anon_sym_LBRACK,
     ACTIONS(15), 1,
       ts_builtin_sym_end,
-    STATE(5), 1,
-      sym_section_name,
-    STATE(9), 1,
-      aux_sym_document_repeat3,
-    STATE(18), 1,
-      sym_section,
-    STATE(6), 2,
+    STATE(3), 1,
       sym_comment,
-      sym__blank,
-  [50] = 8,
+    STATE(4), 1,
+      sym_section_name,
+    STATE(8), 1,
+      aux_sym_document_repeat1,
+    STATE(14), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [50] = 7,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
+      aux_sym_comment_token1,
+    ACTIONS(11), 1,
+      sym_setting_name,
+    STATE(4), 1,
+      sym_comment,
+    STATE(6), 1,
+      aux_sym_unnamed_section_repeat1,
+    STATE(10), 1,
+      sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(17), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+  [74] = 8,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
     ACTIONS(9), 1,
       anon_sym_LBRACK,
-    ACTIONS(17), 1,
+    ACTIONS(15), 1,
       ts_builtin_sym_end,
-    STATE(5), 1,
+    STATE(4), 1,
       sym_section_name,
-    STATE(9), 1,
-      aux_sym_document_repeat3,
-    STATE(18), 1,
-      sym_section,
-    STATE(7), 2,
+    STATE(5), 1,
       sym_comment,
-      sym__blank,
-  [76] = 7,
+    STATE(9), 1,
+      aux_sym_document_repeat1,
+    STATE(14), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [100] = 7,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    ACTIONS(13), 1,
-      aux_sym_setting_token1,
+    ACTIONS(11), 1,
+      sym_setting_name,
+    STATE(6), 1,
+      sym_comment,
+    STATE(7), 1,
+      aux_sym_unnamed_section_repeat1,
     STATE(10), 1,
-      aux_sym_document_repeat2,
-    STATE(13), 1,
       sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(19), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+  [124] = 6,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(23), 1,
+      sym_setting_name,
+    STATE(10), 1,
+      sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
     ACTIONS(21), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-    STATE(8), 2,
+    STATE(7), 2,
       sym_comment,
-      sym__blank,
-  [100] = 7,
-    ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(23), 1,
-      ts_builtin_sym_end,
-    ACTIONS(25), 1,
-      anon_sym_LBRACK,
-    STATE(5), 1,
-      sym_section_name,
-    STATE(18), 1,
-      sym_section,
-    STATE(9), 3,
-      sym_comment,
-      sym__blank,
-      aux_sym_document_repeat3,
-  [124] = 6,
-    ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(30), 1,
-      aux_sym_setting_token1,
-    STATE(13), 1,
-      sym_setting,
-    ACTIONS(28), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-    STATE(10), 3,
-      sym_comment,
-      sym__blank,
-      aux_sym_document_repeat2,
+      aux_sym_unnamed_section_repeat1,
   [146] = 8,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
     ACTIONS(9), 1,
       anon_sym_LBRACK,
-    ACTIONS(33), 1,
+    ACTIONS(26), 1,
       ts_builtin_sym_end,
-    STATE(5), 1,
+    STATE(4), 1,
       sym_section_name,
-    STATE(9), 1,
-      aux_sym_document_repeat3,
-    STATE(18), 1,
-      sym_section,
-    STATE(11), 2,
+    STATE(8), 1,
       sym_comment,
-      sym__blank,
-  [172] = 4,
-    ACTIONS(5), 1,
+    STATE(9), 1,
+      aux_sym_document_repeat1,
+    STATE(14), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [172] = 7,
+    ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(37), 1,
-      aux_sym_section_name_token2,
+    ACTIONS(28), 1,
+      ts_builtin_sym_end,
+    ACTIONS(30), 1,
+      anon_sym_LBRACK,
+    STATE(4), 1,
+      sym_section_name,
+    STATE(14), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    STATE(9), 2,
+      sym_comment,
+      aux_sym_document_repeat1,
+  [196] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    STATE(10), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(33), 3,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+      sym_setting_name,
+  [212] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    STATE(11), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
     ACTIONS(35), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-      aux_sym_setting_token1,
-    STATE(12), 3,
-      sym_comment,
-      sym__blank,
-      aux_sym_document_repeat1,
-  [189] = 4,
+      sym_setting_name,
+  [228] = 4,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    STATE(13), 2,
+    STATE(12), 1,
       sym_comment,
-      sym__blank,
-    ACTIONS(40), 3,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(37), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-      aux_sym_setting_token1,
-  [205] = 4,
+      sym_setting_name,
+  [244] = 4,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    STATE(14), 2,
+    STATE(13), 1,
       sym_comment,
-      sym__blank,
-    ACTIONS(42), 3,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(39), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-      aux_sym_setting_token1,
-  [221] = 4,
+      sym_setting_name,
+  [260] = 4,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    STATE(15), 2,
+    STATE(14), 1,
       sym_comment,
-      sym__blank,
-    ACTIONS(44), 3,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(41), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-      aux_sym_setting_token1,
-  [237] = 4,
-    ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    STATE(16), 2,
-      sym_comment,
-      sym__blank,
-    ACTIONS(46), 3,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      aux_sym_setting_token1,
-  [253] = 3,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    STATE(17), 2,
-      sym_comment,
-      sym__blank,
-    ACTIONS(48), 4,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      aux_sym_section_name_token2,
-      aux_sym_setting_token1,
-  [267] = 4,
-    ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(50), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-    STATE(18), 2,
-      sym_comment,
-      sym__blank,
-  [282] = 4,
-    ACTIONS(52), 1,
+  [275] = 4,
+    ACTIONS(43), 1,
       aux_sym_section_name_token1,
-    ACTIONS(54), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(56), 1,
+    ACTIONS(45), 1,
       aux_sym_comment_token1,
-    STATE(19), 2,
+    STATE(15), 1,
       sym_comment,
-      sym__blank,
-  [296] = 4,
+    ACTIONS(47), 2,
+      sym__eol,
+      sym__space,
+  [289] = 4,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    ACTIONS(58), 1,
-      ts_builtin_sym_end,
-    STATE(20), 2,
-      sym_comment,
-      sym__blank,
-  [310] = 4,
-    ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(60), 1,
+    ACTIONS(49), 1,
       anon_sym_EQ,
-    STATE(21), 2,
+    STATE(16), 1,
       sym_comment,
-      sym__blank,
-  [324] = 4,
-    ACTIONS(54), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(56), 1,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [303] = 5,
+    ACTIONS(45), 1,
       aux_sym_comment_token1,
-    ACTIONS(62), 1,
+    ACTIONS(47), 1,
+      sym__space,
+    ACTIONS(51), 1,
       aux_sym_comment_token2,
-    STATE(22), 2,
+    ACTIONS(53), 1,
+      sym__eol,
+    STATE(17), 1,
       sym_comment,
-      sym__blank,
-  [338] = 4,
+  [319] = 4,
     ACTIONS(3), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(5), 1,
       aux_sym_comment_token1,
-    ACTIONS(64), 1,
-      anon_sym_RBRACK,
-    STATE(23), 2,
-      sym_comment,
-      sym__blank,
-  [352] = 4,
-    ACTIONS(56), 1,
-      aux_sym_comment_token1,
-    ACTIONS(66), 1,
-      aux_sym_section_name_token2,
-    ACTIONS(68), 1,
-      aux_sym_setting_token2,
-    STATE(24), 2,
-      sym_comment,
-      sym__blank,
-  [366] = 3,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(70), 1,
-      aux_sym_section_name_token2,
-    STATE(25), 2,
-      sym_comment,
-      sym__blank,
-  [377] = 3,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(72), 1,
-      aux_sym_section_name_token2,
-    STATE(26), 2,
-      sym_comment,
-      sym__blank,
-  [388] = 3,
-    ACTIONS(5), 1,
-      aux_sym_comment_token1,
-    ACTIONS(74), 1,
-      aux_sym_section_name_token2,
-    STATE(27), 2,
-      sym_comment,
-      sym__blank,
-  [399] = 1,
-    ACTIONS(48), 1,
+    ACTIONS(55), 1,
       ts_builtin_sym_end,
-  [403] = 1,
-    ACTIONS(76), 1,
+    STATE(18), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [333] = 5,
+    ACTIONS(45), 1,
+      aux_sym_comment_token1,
+    ACTIONS(47), 1,
+      sym__space,
+    ACTIONS(57), 1,
+      sym_setting_value,
+    ACTIONS(59), 1,
+      sym__eol,
+    STATE(19), 1,
+      sym_comment,
+  [349] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(61), 1,
+      anon_sym_RBRACK,
+    STATE(20), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [363] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(63), 1,
+      sym__eol,
+    STATE(21), 1,
+      sym_comment,
+  [376] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(65), 1,
+      sym__eol,
+    STATE(22), 1,
+      sym_comment,
+  [389] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(67), 1,
+      sym__eol,
+    STATE(23), 1,
+      sym_comment,
+  [402] = 1,
+    ACTIONS(69), 1,
+      ts_builtin_sym_end,
+  [406] = 1,
+    ACTIONS(71), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(5)] = 0,
-  [SMALL_STATE(6)] = 24,
-  [SMALL_STATE(7)] = 50,
-  [SMALL_STATE(8)] = 76,
-  [SMALL_STATE(9)] = 100,
-  [SMALL_STATE(10)] = 124,
-  [SMALL_STATE(11)] = 146,
-  [SMALL_STATE(12)] = 172,
-  [SMALL_STATE(13)] = 189,
-  [SMALL_STATE(14)] = 205,
-  [SMALL_STATE(15)] = 221,
-  [SMALL_STATE(16)] = 237,
-  [SMALL_STATE(17)] = 253,
-  [SMALL_STATE(18)] = 267,
-  [SMALL_STATE(19)] = 282,
-  [SMALL_STATE(20)] = 296,
-  [SMALL_STATE(21)] = 310,
-  [SMALL_STATE(22)] = 324,
-  [SMALL_STATE(23)] = 338,
-  [SMALL_STATE(24)] = 352,
-  [SMALL_STATE(25)] = 366,
-  [SMALL_STATE(26)] = 377,
-  [SMALL_STATE(27)] = 388,
-  [SMALL_STATE(28)] = 399,
-  [SMALL_STATE(29)] = 403,
+  [SMALL_STATE(2)] = 0,
+  [SMALL_STATE(3)] = 24,
+  [SMALL_STATE(4)] = 50,
+  [SMALL_STATE(5)] = 74,
+  [SMALL_STATE(6)] = 100,
+  [SMALL_STATE(7)] = 124,
+  [SMALL_STATE(8)] = 146,
+  [SMALL_STATE(9)] = 172,
+  [SMALL_STATE(10)] = 196,
+  [SMALL_STATE(11)] = 212,
+  [SMALL_STATE(12)] = 228,
+  [SMALL_STATE(13)] = 244,
+  [SMALL_STATE(14)] = 260,
+  [SMALL_STATE(15)] = 275,
+  [SMALL_STATE(16)] = 289,
+  [SMALL_STATE(17)] = 303,
+  [SMALL_STATE(18)] = 319,
+  [SMALL_STATE(19)] = 333,
+  [SMALL_STATE(20)] = 349,
+  [SMALL_STATE(21)] = 363,
+  [SMALL_STATE(22)] = 376,
+  [SMALL_STATE(23)] = 389,
+  [SMALL_STATE(24)] = 402,
+  [SMALL_STATE(25)] = 406,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [7] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unnamed_section, 1, 0, 0),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat3, 2, 0, 0),
-  [25] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat3, 2, 0, 0), SHIFT_REPEAT(19),
-  [28] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0),
-  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 2, 0, 0), SHIFT_REPEAT(21),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, 0, 0),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [37] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
-  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat2, 1, 0, 0),
-  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
-  [44] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
-  [46] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
-  [48] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__blank, 1, 0, 1),
-  [50] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat3, 1, 0, 0),
-  [52] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [54] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [56] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [58] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [60] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [62] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [66] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [68] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [76] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
+  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
+  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0),
+  [23] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
+  [26] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
+  [28] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 1, 0, 0),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
+  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1, 0, 0),
+  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [55] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
 };
 
 #ifdef __cplusplus
@@ -885,9 +812,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_ini(void) {
     .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
-    .field_names = ts_field_names,
-    .field_map_slices = ts_field_map_slices,
-    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,11 +7,11 @@
 #endif
 
 #define LANGUAGE_VERSION 15
-#define STATE_COUNT 26
+#define STATE_COUNT 37
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 19
+#define SYMBOL_COUNT 27
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 11
+#define TOKEN_COUNT 13
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 4
@@ -25,19 +25,27 @@ enum ts_symbol_identifiers {
   anon_sym_RBRACK = 3,
   anon_sym_EQ = 4,
   sym_setting_name = 5,
-  sym_setting_value = 6,
-  aux_sym_comment_token1 = 7,
-  aux_sym_comment_token2 = 8,
-  sym__eol = 9,
-  sym__space = 10,
-  sym_document = 11,
-  sym_unnamed_section = 12,
-  sym_section = 13,
-  sym_section_name = 14,
-  sym_setting = 15,
-  sym_comment = 16,
-  aux_sym_document_repeat1 = 17,
-  aux_sym_unnamed_section_repeat1 = 18,
+  aux_sym_setting_text_token1 = 6,
+  sym__line_cont = 7,
+  anon_sym_BSLASH_BSLASH = 8,
+  aux_sym_comment_token1 = 9,
+  aux_sym_comment_token2 = 10,
+  sym__eol = 11,
+  sym__space = 12,
+  sym_document = 13,
+  sym_unnamed_section = 14,
+  sym_section = 15,
+  sym_section_name = 16,
+  sym_setting = 17,
+  sym_setting_value = 18,
+  sym_setting_value_cont = 19,
+  sym_setting_text = 20,
+  sym__esc_bkslsh = 21,
+  sym_comment = 22,
+  aux_sym_document_repeat1 = 23,
+  aux_sym_unnamed_section_repeat1 = 24,
+  aux_sym_setting_value_repeat1 = 25,
+  aux_sym_setting_text_repeat1 = 26,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -47,7 +55,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RBRACK] = "]",
   [anon_sym_EQ] = "=",
   [sym_setting_name] = "setting_name",
-  [sym_setting_value] = "setting_value",
+  [aux_sym_setting_text_token1] = "setting_text_token1",
+  [sym__line_cont] = "_line_cont",
+  [anon_sym_BSLASH_BSLASH] = "\\\\",
   [aux_sym_comment_token1] = "comment_token1",
   [aux_sym_comment_token2] = "text",
   [sym__eol] = "_eol",
@@ -57,9 +67,15 @@ static const char * const ts_symbol_names[] = {
   [sym_section] = "section",
   [sym_section_name] = "section_name",
   [sym_setting] = "setting",
+  [sym_setting_value] = "setting_value",
+  [sym_setting_value_cont] = "setting_value_cont",
+  [sym_setting_text] = "setting_text",
+  [sym__esc_bkslsh] = "_esc_bkslsh",
   [sym_comment] = "comment",
   [aux_sym_document_repeat1] = "document_repeat1",
   [aux_sym_unnamed_section_repeat1] = "unnamed_section_repeat1",
+  [aux_sym_setting_value_repeat1] = "setting_value_repeat1",
+  [aux_sym_setting_text_repeat1] = "setting_text_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -69,7 +85,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [anon_sym_EQ] = anon_sym_EQ,
   [sym_setting_name] = sym_setting_name,
-  [sym_setting_value] = sym_setting_value,
+  [aux_sym_setting_text_token1] = aux_sym_setting_text_token1,
+  [sym__line_cont] = sym__line_cont,
+  [anon_sym_BSLASH_BSLASH] = anon_sym_BSLASH_BSLASH,
   [aux_sym_comment_token1] = aux_sym_comment_token1,
   [aux_sym_comment_token2] = aux_sym_section_name_token1,
   [sym__eol] = sym__eol,
@@ -79,9 +97,15 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_section] = sym_section,
   [sym_section_name] = sym_section_name,
   [sym_setting] = sym_setting,
+  [sym_setting_value] = sym_setting_value,
+  [sym_setting_value_cont] = sym_setting_value_cont,
+  [sym_setting_text] = sym_setting_text,
+  [sym__esc_bkslsh] = sym__esc_bkslsh,
   [sym_comment] = sym_comment,
   [aux_sym_document_repeat1] = aux_sym_document_repeat1,
   [aux_sym_unnamed_section_repeat1] = aux_sym_unnamed_section_repeat1,
+  [aux_sym_setting_value_repeat1] = aux_sym_setting_value_repeat1,
+  [aux_sym_setting_text_repeat1] = aux_sym_setting_text_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -109,9 +133,17 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_setting_value] = {
-    .visible = true,
+  [aux_sym_setting_text_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym__line_cont] = {
+    .visible = false,
     .named = true,
+  },
+  [anon_sym_BSLASH_BSLASH] = {
+    .visible = true,
+    .named = false,
   },
   [aux_sym_comment_token1] = {
     .visible = false,
@@ -149,6 +181,22 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_setting_value] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_setting_value_cont] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_setting_text] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__esc_bkslsh] = {
+    .visible = false,
+    .named = true,
+  },
   [sym_comment] = {
     .visible = true,
     .named = true,
@@ -158,6 +206,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_unnamed_section_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_setting_value_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_setting_text_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -198,6 +254,17 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [23] = 23,
   [24] = 24,
   [25] = 25,
+  [26] = 26,
+  [27] = 27,
+  [28] = 28,
+  [29] = 29,
+  [30] = 30,
+  [31] = 31,
+  [32] = 32,
+  [33] = 33,
+  [34] = 34,
+  [35] = 35,
+  [36] = 36,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -205,26 +272,28 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(9);
+      if (eof) ADVANCE(10);
       ADVANCE_MAP(
-        '\n', 22,
+        '\n', 24,
         '\r', 1,
-        '=', 14,
-        '[', 10,
-        ']', 13,
-        '\t', 23,
-        ' ', 23,
-        '#', 19,
-        ';', 19,
+        '=', 15,
+        '[', 11,
+        '\\', 18,
+        ']', 14,
+        '\t', 17,
+        ' ', 17,
+        '#', 17,
+        ';', 17,
       );
+      if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(24);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(24);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '\\') ADVANCE(6);
+      if (lookahead == '\\') ADVANCE(18);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(17);
       if (lookahead == '#' ||
@@ -232,131 +301,137 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(17);
       END_STATE();
     case 3:
-      if (lookahead == '\n') ADVANCE(22);
-      if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(21);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(20);
-      if (lookahead != 0) ADVANCE(21);
+      ADVANCE_MAP(
+        '\n', 24,
+        '\r', 1,
+        '\\', 6,
+        ']', 14,
+        '\t', 25,
+        ' ', 25,
+        '#', 21,
+        ';', 21,
+      );
       END_STATE();
     case 4:
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '\r') ADVANCE(11);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(12);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(12);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(12);
-      END_STATE();
-    case 5:
-      if (lookahead == '\n') ADVANCE(18);
-      END_STATE();
-    case 6:
-      if (lookahead == '\n') ADVANCE(18);
-      if (lookahead == '\r') ADVANCE(5);
-      if (lookahead == '\\') ADVANCE(6);
-      if (lookahead != 0) ADVANCE(17);
-      END_STATE();
-    case 7:
-      if (lookahead == ' ') ADVANCE(7);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '#' &&
-          lookahead != ';' &&
-          lookahead != '=' &&
-          lookahead != '[') ADVANCE(15);
-      END_STATE();
-    case 8:
-      if (eof) ADVANCE(9);
-      if (lookahead == '\n') ADVANCE(22);
+      if (lookahead == '\n') ADVANCE(24);
       if (lookahead == '\r') ADVANCE(1);
-      if (lookahead == '[') ADVANCE(10);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(23);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(19);
-      if (lookahead != 0 &&
-          (lookahead < '\t' || '\r' < lookahead) &&
-          lookahead != '=') ADVANCE(15);
+          lookahead == ';') ADVANCE(22);
+      if (lookahead != 0) ADVANCE(23);
       END_STATE();
-    case 9:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+    case 5:
+      if (lookahead == '\n') ADVANCE(19);
       END_STATE();
-    case 10:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+    case 6:
+      if (lookahead == '\n') ADVANCE(19);
+      if (lookahead == '\r') ADVANCE(5);
       END_STATE();
-    case 11:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead != 0 &&
-          lookahead != '[' &&
-          lookahead != ']') ADVANCE(12);
-      END_STATE();
-    case 12:
-      ACCEPT_TOKEN(aux_sym_section_name_token1);
+    case 7:
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead == '\r') ADVANCE(12);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(13);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(13);
       if (lookahead != 0 &&
           lookahead != '[' &&
-          lookahead != ']') ADVANCE(12);
+          lookahead != ']') ADVANCE(13);
       END_STATE();
-    case 13:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 14:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      END_STATE();
-    case 15:
-      ACCEPT_TOKEN(sym_setting_name);
-      if (lookahead == ' ') ADVANCE(7);
+    case 8:
+      if (lookahead == ' ') ADVANCE(8);
       if (lookahead != 0 &&
           (lookahead < '\t' || '\r' < lookahead) &&
           lookahead != '#' &&
           lookahead != ';' &&
           lookahead != '=' &&
-          lookahead != '[') ADVANCE(15);
+          lookahead != '[') ADVANCE(16);
+      END_STATE();
+    case 9:
+      if (eof) ADVANCE(10);
+      ADVANCE_MAP(
+        '\n', 24,
+        '\r', 1,
+        '=', 15,
+        '[', 11,
+        '\t', 25,
+        ' ', 25,
+        '#', 21,
+        ';', 21,
+      );
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(16);
+      END_STATE();
+    case 10:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 11:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 12:
+      ACCEPT_TOKEN(aux_sym_section_name_token1);
+      if (lookahead == '\n') ADVANCE(13);
+      if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']') ADVANCE(13);
+      END_STATE();
+    case 13:
+      ACCEPT_TOKEN(aux_sym_section_name_token1);
+      if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']') ADVANCE(13);
+      END_STATE();
+    case 14:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 15:
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 16:
-      ACCEPT_TOKEN(sym_setting_value);
-      if (lookahead == '\n') ADVANCE(18);
-      if (lookahead == '\r') ADVANCE(5);
-      if (lookahead == '\\') ADVANCE(16);
-      if (lookahead != 0) ADVANCE(18);
+      ACCEPT_TOKEN(sym_setting_name);
+      if (lookahead == ' ') ADVANCE(8);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead) &&
+          lookahead != '#' &&
+          lookahead != ';' &&
+          lookahead != '=' &&
+          lookahead != '[') ADVANCE(16);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(sym_setting_value);
-      if (lookahead == '\\') ADVANCE(6);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(17);
+      ACCEPT_TOKEN(aux_sym_setting_text_token1);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(sym_setting_value);
-      if (lookahead == '\\') ADVANCE(16);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(18);
+      ACCEPT_TOKEN(aux_sym_setting_text_token1);
+      if (lookahead == '\n') ADVANCE(19);
+      if (lookahead == '\r') ADVANCE(5);
+      if (lookahead == '\\') ADVANCE(20);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(aux_sym_comment_token1);
+      ACCEPT_TOKEN(sym__line_cont);
       END_STATE();
     case 20:
+      ACCEPT_TOKEN(anon_sym_BSLASH_BSLASH);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(aux_sym_comment_token1);
+      END_STATE();
+    case 22:
       ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(21);
+          lookahead != '\r') ADVANCE(23);
       END_STATE();
-    case 21:
+    case 23:
       ACCEPT_TOKEN(aux_sym_comment_token2);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(21);
+          lookahead != '\r') ADVANCE(23);
       END_STATE();
-    case 22:
+    case 24:
       ACCEPT_TOKEN(sym__eol);
       END_STATE();
-    case 23:
+    case 25:
       ACCEPT_TOKEN(sym__space);
       END_STATE();
     default:
@@ -366,31 +441,42 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 8},
-  [2] = {.lex_state = 8},
-  [3] = {.lex_state = 0},
-  [4] = {.lex_state = 8},
-  [5] = {.lex_state = 0},
-  [6] = {.lex_state = 8},
-  [7] = {.lex_state = 8},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 8},
-  [11] = {.lex_state = 8},
-  [12] = {.lex_state = 8},
-  [13] = {.lex_state = 8},
-  [14] = {.lex_state = 0},
-  [15] = {.lex_state = 4},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 3},
-  [18] = {.lex_state = 0},
-  [19] = {.lex_state = 2},
-  [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 0},
-  [23] = {.lex_state = 0},
-  [24] = {(TSStateId)(-1),},
-  [25] = {(TSStateId)(-1),},
+  [1] = {.lex_state = 9},
+  [2] = {.lex_state = 2},
+  [3] = {.lex_state = 2},
+  [4] = {.lex_state = 9},
+  [5] = {.lex_state = 9},
+  [6] = {.lex_state = 9},
+  [7] = {.lex_state = 9},
+  [8] = {.lex_state = 9},
+  [9] = {.lex_state = 9},
+  [10] = {.lex_state = 9},
+  [11] = {.lex_state = 9},
+  [12] = {.lex_state = 2},
+  [13] = {.lex_state = 2},
+  [14] = {.lex_state = 9},
+  [15] = {.lex_state = 9},
+  [16] = {.lex_state = 2},
+  [17] = {.lex_state = 2},
+  [18] = {.lex_state = 9},
+  [19] = {.lex_state = 3},
+  [20] = {.lex_state = 9},
+  [21] = {.lex_state = 3},
+  [22] = {.lex_state = 3},
+  [23] = {.lex_state = 3},
+  [24] = {.lex_state = 9},
+  [25] = {.lex_state = 3},
+  [26] = {.lex_state = 4},
+  [27] = {.lex_state = 9},
+  [28] = {.lex_state = 7},
+  [29] = {.lex_state = 3},
+  [30] = {.lex_state = 9},
+  [31] = {.lex_state = 3},
+  [32] = {.lex_state = 9},
+  [33] = {.lex_state = 9},
+  [34] = {.lex_state = 9},
+  [35] = {(TSStateId)(-1),},
+  [36] = {(TSStateId)(-1),},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -400,387 +486,594 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_EQ] = ACTIONS(1),
+    [aux_sym_setting_text_token1] = ACTIONS(1),
+    [sym__line_cont] = ACTIONS(1),
+    [anon_sym_BSLASH_BSLASH] = ACTIONS(1),
     [aux_sym_comment_token1] = ACTIONS(3),
     [sym__eol] = ACTIONS(5),
-    [sym__space] = ACTIONS(5),
+    [sym__space] = ACTIONS(7),
   },
   [STATE(1)] = {
-    [sym_document] = STATE(18),
-    [sym_unnamed_section] = STATE(3),
-    [sym_section] = STATE(14),
-    [sym_section_name] = STATE(4),
-    [sym_setting] = STATE(10),
+    [sym_document] = STATE(27),
+    [sym_unnamed_section] = STATE(6),
+    [sym_section] = STATE(24),
+    [sym_section_name] = STATE(7),
+    [sym_setting] = STATE(14),
     [sym_comment] = STATE(1),
-    [aux_sym_document_repeat1] = STATE(5),
-    [aux_sym_unnamed_section_repeat1] = STATE(2),
-    [ts_builtin_sym_end] = ACTIONS(7),
-    [anon_sym_LBRACK] = ACTIONS(9),
-    [sym_setting_name] = ACTIONS(11),
-    [aux_sym_comment_token1] = ACTIONS(3),
+    [aux_sym_document_repeat1] = STATE(9),
+    [aux_sym_unnamed_section_repeat1] = STATE(8),
+    [ts_builtin_sym_end] = ACTIONS(9),
+    [anon_sym_LBRACK] = ACTIONS(11),
+    [sym_setting_name] = ACTIONS(13),
+    [aux_sym_comment_token1] = ACTIONS(15),
     [sym__eol] = ACTIONS(5),
     [sym__space] = ACTIONS(5),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 7,
+  [0] = 13,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(11), 1,
-      sym_setting_name,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(17), 1,
+      aux_sym_setting_text_token1,
+    ACTIONS(19), 1,
+      sym__line_cont,
+    ACTIONS(21), 1,
+      anon_sym_BSLASH_BSLASH,
+    ACTIONS(23), 1,
+      sym__eol,
     STATE(2), 1,
       sym_comment,
-    STATE(7), 1,
-      aux_sym_unnamed_section_repeat1,
-    STATE(10), 1,
-      sym_setting,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(13), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-  [24] = 8,
+    STATE(12), 1,
+      aux_sym_setting_text_repeat1,
+    STATE(16), 1,
+      sym__esc_bkslsh,
+    STATE(19), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(21), 1,
+      sym_setting_text,
+    STATE(31), 1,
+      sym_setting_value_cont,
+    STATE(33), 1,
+      sym_setting_value,
+  [40] = 9,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(9), 1,
-      anon_sym_LBRACK,
-    ACTIONS(15), 1,
-      ts_builtin_sym_end,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(17), 1,
+      aux_sym_setting_text_token1,
+    ACTIONS(21), 1,
+      anon_sym_BSLASH_BSLASH,
     STATE(3), 1,
       sym_comment,
+    STATE(12), 1,
+      aux_sym_setting_text_repeat1,
+    STATE(16), 1,
+      sym__esc_bkslsh,
+    STATE(29), 1,
+      sym_setting_text,
+    ACTIONS(25), 2,
+      sym__line_cont,
+      sym__eol,
+  [69] = 8,
+    ACTIONS(11), 1,
+      anon_sym_LBRACK,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(27), 1,
+      ts_builtin_sym_end,
     STATE(4), 1,
+      sym_comment,
+    STATE(7), 1,
       sym_section_name,
-    STATE(8), 1,
+    STATE(10), 1,
       aux_sym_document_repeat1,
-    STATE(14), 1,
+    STATE(24), 1,
       sym_section,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-  [50] = 7,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(11), 1,
+  [95] = 7,
+    ACTIONS(13), 1,
       sym_setting_name,
-    STATE(4), 1,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    STATE(5), 1,
       sym_comment,
-    STATE(6), 1,
+    STATE(11), 1,
       aux_sym_unnamed_section_repeat1,
-    STATE(10), 1,
+    STATE(14), 1,
       sym_setting,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(17), 2,
+    ACTIONS(29), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-  [74] = 8,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(9), 1,
+  [119] = 8,
+    ACTIONS(11), 1,
       anon_sym_LBRACK,
     ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(31), 1,
       ts_builtin_sym_end,
     STATE(4), 1,
-      sym_section_name,
-    STATE(5), 1,
-      sym_comment,
-    STATE(9), 1,
       aux_sym_document_repeat1,
-    STATE(14), 1,
-      sym_section,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [100] = 7,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(11), 1,
-      sym_setting_name,
     STATE(6), 1,
       sym_comment,
     STATE(7), 1,
-      aux_sym_unnamed_section_repeat1,
-    STATE(10), 1,
-      sym_setting,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(19), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-  [124] = 6,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(23), 1,
-      sym_setting_name,
-    STATE(10), 1,
-      sym_setting,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(21), 2,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-    STATE(7), 2,
-      sym_comment,
-      aux_sym_unnamed_section_repeat1,
-  [146] = 8,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(9), 1,
-      anon_sym_LBRACK,
-    ACTIONS(26), 1,
-      ts_builtin_sym_end,
-    STATE(4), 1,
       sym_section_name,
+    STATE(24), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [145] = 7,
+    ACTIONS(13), 1,
+      sym_setting_name,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    STATE(5), 1,
+      aux_sym_unnamed_section_repeat1,
+    STATE(7), 1,
+      sym_comment,
+    STATE(14), 1,
+      sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(33), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+  [169] = 7,
+    ACTIONS(13), 1,
+      sym_setting_name,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
     STATE(8), 1,
       sym_comment,
-    STATE(9), 1,
-      aux_sym_document_repeat1,
-    STATE(14), 1,
-      sym_section,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-  [172] = 7,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(28), 1,
-      ts_builtin_sym_end,
-    ACTIONS(30), 1,
-      anon_sym_LBRACK,
-    STATE(4), 1,
-      sym_section_name,
-    STATE(14), 1,
-      sym_section,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    STATE(9), 2,
-      sym_comment,
-      aux_sym_document_repeat1,
-  [196] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    STATE(10), 1,
-      sym_comment,
-    ACTIONS(5), 2,
-      sym__eol,
-      sym__space,
-    ACTIONS(33), 3,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      sym_setting_name,
-  [212] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
     STATE(11), 1,
-      sym_comment,
+      aux_sym_unnamed_section_repeat1,
+    STATE(14), 1,
+      sym_setting,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(35), 3,
+    ACTIONS(35), 2,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
+  [193] = 8,
+    ACTIONS(11), 1,
+      anon_sym_LBRACK,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(31), 1,
+      ts_builtin_sym_end,
+    STATE(7), 1,
+      sym_section_name,
+    STATE(9), 1,
+      sym_comment,
+    STATE(10), 1,
+      aux_sym_document_repeat1,
+    STATE(24), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [219] = 7,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(37), 1,
+      ts_builtin_sym_end,
+    ACTIONS(39), 1,
+      anon_sym_LBRACK,
+    STATE(7), 1,
+      sym_section_name,
+    STATE(24), 1,
+      sym_section,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    STATE(10), 2,
+      sym_comment,
+      aux_sym_document_repeat1,
+  [243] = 6,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(44), 1,
       sym_setting_name,
-  [228] = 4,
+    STATE(14), 1,
+      sym_setting,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(42), 2,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+    STATE(11), 2,
+      sym_comment,
+      aux_sym_unnamed_section_repeat1,
+  [265] = 8,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(17), 1,
+      aux_sym_setting_text_token1,
+    ACTIONS(21), 1,
+      anon_sym_BSLASH_BSLASH,
     STATE(12), 1,
       sym_comment,
-    ACTIONS(5), 2,
+    STATE(13), 1,
+      aux_sym_setting_text_repeat1,
+    STATE(16), 1,
+      sym__esc_bkslsh,
+    ACTIONS(47), 2,
+      sym__line_cont,
       sym__eol,
-      sym__space,
-    ACTIONS(37), 3,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      sym_setting_name,
-  [244] = 4,
+  [291] = 7,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    STATE(13), 1,
-      sym_comment,
-    ACTIONS(5), 2,
-      sym__eol,
+    ACTIONS(7), 1,
       sym__space,
-    ACTIONS(39), 3,
-      ts_builtin_sym_end,
-      anon_sym_LBRACK,
-      sym_setting_name,
-  [260] = 4,
-    ACTIONS(3), 1,
+    ACTIONS(49), 1,
+      aux_sym_setting_text_token1,
+    ACTIONS(54), 1,
+      anon_sym_BSLASH_BSLASH,
+    STATE(16), 1,
+      sym__esc_bkslsh,
+    ACTIONS(52), 2,
+      sym__line_cont,
+      sym__eol,
+    STATE(13), 2,
+      sym_comment,
+      aux_sym_setting_text_repeat1,
+  [315] = 4,
+    ACTIONS(15), 1,
       aux_sym_comment_token1,
     STATE(14), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-    ACTIONS(41), 2,
+    ACTIONS(57), 3,
       ts_builtin_sym_end,
       anon_sym_LBRACK,
-  [275] = 4,
-    ACTIONS(43), 1,
-      aux_sym_section_name_token1,
-    ACTIONS(45), 1,
+      sym_setting_name,
+  [331] = 4,
+    ACTIONS(15), 1,
       aux_sym_comment_token1,
     STATE(15), 1,
       sym_comment,
-    ACTIONS(47), 2,
-      sym__eol,
-      sym__space,
-  [289] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
-    ACTIONS(49), 1,
-      anon_sym_EQ,
-    STATE(16), 1,
-      sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-  [303] = 5,
-    ACTIONS(45), 1,
-      aux_sym_comment_token1,
-    ACTIONS(47), 1,
-      sym__space,
-    ACTIONS(51), 1,
-      aux_sym_comment_token2,
-    ACTIONS(53), 1,
-      sym__eol,
-    STATE(17), 1,
-      sym_comment,
-  [319] = 4,
+    ACTIONS(59), 3,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+      sym_setting_name,
+  [347] = 5,
     ACTIONS(3), 1,
       aux_sym_comment_token1,
-    ACTIONS(55), 1,
-      ts_builtin_sym_end,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(61), 1,
+      aux_sym_setting_text_token1,
+    STATE(16), 1,
+      sym_comment,
+    ACTIONS(63), 3,
+      sym__line_cont,
+      anon_sym_BSLASH_BSLASH,
+      sym__eol,
+  [365] = 5,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(65), 1,
+      aux_sym_setting_text_token1,
+    STATE(17), 1,
+      sym_comment,
+    ACTIONS(67), 3,
+      sym__line_cont,
+      anon_sym_BSLASH_BSLASH,
+      sym__eol,
+  [383] = 4,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
     STATE(18), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-  [333] = 5,
-    ACTIONS(45), 1,
-      aux_sym_comment_token1,
-    ACTIONS(47), 1,
+    ACTIONS(69), 3,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+      sym_setting_name,
+  [399] = 7,
+    ACTIONS(5), 1,
       sym__space,
-    ACTIONS(57), 1,
-      sym_setting_value,
-    ACTIONS(59), 1,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(19), 1,
+      sym__line_cont,
+    ACTIONS(71), 1,
       sym__eol,
     STATE(19), 1,
       sym_comment,
-  [349] = 4,
-    ACTIONS(3), 1,
+    STATE(23), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(31), 1,
+      sym_setting_value_cont,
+  [421] = 4,
+    ACTIONS(15), 1,
       aux_sym_comment_token1,
-    ACTIONS(61), 1,
-      anon_sym_RBRACK,
     STATE(20), 1,
       sym_comment,
     ACTIONS(5), 2,
       sym__eol,
       sym__space,
-  [363] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
+    ACTIONS(73), 3,
+      ts_builtin_sym_end,
+      anon_sym_LBRACK,
+      sym_setting_name,
+  [437] = 7,
     ACTIONS(5), 1,
       sym__space,
-    ACTIONS(63), 1,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(19), 1,
+      sym__line_cont,
+    ACTIONS(71), 1,
       sym__eol,
     STATE(21), 1,
       sym_comment,
-  [376] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
+    STATE(22), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(31), 1,
+      sym_setting_value_cont,
+  [459] = 7,
     ACTIONS(5), 1,
       sym__space,
-    ACTIONS(65), 1,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(19), 1,
+      sym__line_cont,
+    ACTIONS(75), 1,
       sym__eol,
     STATE(22), 1,
       sym_comment,
-  [389] = 4,
-    ACTIONS(3), 1,
-      aux_sym_comment_token1,
+    STATE(23), 1,
+      aux_sym_setting_value_repeat1,
+    STATE(31), 1,
+      sym_setting_value_cont,
+  [481] = 6,
     ACTIONS(5), 1,
       sym__space,
-    ACTIONS(67), 1,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(77), 1,
+      sym__line_cont,
+    ACTIONS(80), 1,
       sym__eol,
-    STATE(23), 1,
+    STATE(31), 1,
+      sym_setting_value_cont,
+    STATE(23), 2,
       sym_comment,
-  [402] = 1,
-    ACTIONS(69), 1,
+      aux_sym_setting_value_repeat1,
+  [501] = 4,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    STATE(24), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+    ACTIONS(82), 2,
       ts_builtin_sym_end,
-  [406] = 1,
-    ACTIONS(71), 1,
+      anon_sym_LBRACK,
+  [516] = 4,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(84), 1,
+      anon_sym_RBRACK,
+    STATE(25), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [530] = 5,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(7), 1,
+      sym__space,
+    ACTIONS(86), 1,
+      aux_sym_comment_token2,
+    ACTIONS(88), 1,
+      sym__eol,
+    STATE(26), 1,
+      sym_comment,
+  [546] = 4,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(90), 1,
+      ts_builtin_sym_end,
+    STATE(27), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [560] = 4,
+    ACTIONS(3), 1,
+      aux_sym_comment_token1,
+    ACTIONS(92), 1,
+      aux_sym_section_name_token1,
+    STATE(28), 1,
+      sym_comment,
+    ACTIONS(7), 2,
+      sym__eol,
+      sym__space,
+  [574] = 4,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    STATE(29), 1,
+      sym_comment,
+    ACTIONS(94), 2,
+      sym__line_cont,
+      sym__eol,
+  [588] = 4,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(96), 1,
+      anon_sym_EQ,
+    STATE(30), 1,
+      sym_comment,
+    ACTIONS(5), 2,
+      sym__eol,
+      sym__space,
+  [602] = 4,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    STATE(31), 1,
+      sym_comment,
+    ACTIONS(98), 2,
+      sym__line_cont,
+      sym__eol,
+  [616] = 4,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(100), 1,
+      sym__eol,
+    STATE(32), 1,
+      sym_comment,
+  [629] = 4,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(102), 1,
+      sym__eol,
+    STATE(33), 1,
+      sym_comment,
+  [642] = 4,
+    ACTIONS(5), 1,
+      sym__space,
+    ACTIONS(15), 1,
+      aux_sym_comment_token1,
+    ACTIONS(104), 1,
+      sym__eol,
+    STATE(34), 1,
+      sym_comment,
+  [655] = 1,
+    ACTIONS(106), 1,
+      ts_builtin_sym_end,
+  [659] = 1,
+    ACTIONS(108), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 24,
-  [SMALL_STATE(4)] = 50,
-  [SMALL_STATE(5)] = 74,
-  [SMALL_STATE(6)] = 100,
-  [SMALL_STATE(7)] = 124,
-  [SMALL_STATE(8)] = 146,
-  [SMALL_STATE(9)] = 172,
-  [SMALL_STATE(10)] = 196,
-  [SMALL_STATE(11)] = 212,
-  [SMALL_STATE(12)] = 228,
-  [SMALL_STATE(13)] = 244,
-  [SMALL_STATE(14)] = 260,
-  [SMALL_STATE(15)] = 275,
-  [SMALL_STATE(16)] = 289,
-  [SMALL_STATE(17)] = 303,
-  [SMALL_STATE(18)] = 319,
-  [SMALL_STATE(19)] = 333,
-  [SMALL_STATE(20)] = 349,
-  [SMALL_STATE(21)] = 363,
-  [SMALL_STATE(22)] = 376,
-  [SMALL_STATE(23)] = 389,
-  [SMALL_STATE(24)] = 402,
-  [SMALL_STATE(25)] = 406,
+  [SMALL_STATE(3)] = 40,
+  [SMALL_STATE(4)] = 69,
+  [SMALL_STATE(5)] = 95,
+  [SMALL_STATE(6)] = 119,
+  [SMALL_STATE(7)] = 145,
+  [SMALL_STATE(8)] = 169,
+  [SMALL_STATE(9)] = 193,
+  [SMALL_STATE(10)] = 219,
+  [SMALL_STATE(11)] = 243,
+  [SMALL_STATE(12)] = 265,
+  [SMALL_STATE(13)] = 291,
+  [SMALL_STATE(14)] = 315,
+  [SMALL_STATE(15)] = 331,
+  [SMALL_STATE(16)] = 347,
+  [SMALL_STATE(17)] = 365,
+  [SMALL_STATE(18)] = 383,
+  [SMALL_STATE(19)] = 399,
+  [SMALL_STATE(20)] = 421,
+  [SMALL_STATE(21)] = 437,
+  [SMALL_STATE(22)] = 459,
+  [SMALL_STATE(23)] = 481,
+  [SMALL_STATE(24)] = 501,
+  [SMALL_STATE(25)] = 516,
+  [SMALL_STATE(26)] = 530,
+  [SMALL_STATE(27)] = 546,
+  [SMALL_STATE(28)] = 560,
+  [SMALL_STATE(29)] = 574,
+  [SMALL_STATE(30)] = 588,
+  [SMALL_STATE(31)] = 602,
+  [SMALL_STATE(32)] = 616,
+  [SMALL_STATE(33)] = 629,
+  [SMALL_STATE(34)] = 642,
+  [SMALL_STATE(35)] = 655,
+  [SMALL_STATE(36)] = 659,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [7] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [13] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unnamed_section, 1, 0, 0),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
-  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
-  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0),
-  [23] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
-  [26] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
-  [28] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
-  [30] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 1, 0, 0),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
-  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
-  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1, 0, 0),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [55] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [63] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [65] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [25] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 1, 0, 0),
+  [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
+  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 2, 0, 0),
+  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unnamed_section, 1, 0, 0),
+  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(28),
+  [42] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0),
+  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_text, 1, 0, 0),
+  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0), SHIFT_REPEAT(16),
+  [52] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0),
+  [54] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
+  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_unnamed_section_repeat1, 1, 0, 0),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 4, 0, 0),
+  [61] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_setting_text_repeat1, 1, 0, 0),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_text_repeat1, 1, 0, 0),
+  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__esc_bkslsh, 1, 0, 0),
+  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__esc_bkslsh, 1, 0, 0),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting, 3, 0, 0),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 1, 0, 0),
+  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section_name, 4, 0, 0),
+  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value, 2, 0, 0),
+  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 2, 0, 0),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 1, 0, 0),
+  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
+  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [90] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_value_cont, 2, 0, 0),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [98] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_setting_value_repeat1, 1, 0, 0),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2, 0, 0),
+  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 3, 0, 0),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -18,15 +18,15 @@ still = value
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont
-          (setting_text_cont))
+          (text))
         (setting_value_cont
-          (setting_text_cont))
+          (text))
         (setting_value_cont
-          (setting_text_cont))
+          (text))
         (setting_value_cont
-          (setting_text_cont))))))
+          (text))))))
 
 ================================================================================
 comments in continued lines
@@ -46,17 +46,17 @@ value3
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont
           (comment
             (text))
           (comment
             (text))
-          (setting_text_cont))
+          (text))
         (setting_value_cont
           (comment
             (text))
-          (setting_text_cont))))))
+          (text))))))
 
 ================================================================================
 empty continued lines
@@ -83,30 +83,30 @@ foo = 3
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont)
         (setting_value_cont
-          (setting_text_cont))
+          (text))
         (setting_value_cont)
         (setting_value_cont)
         (setting_value_cont
-          (setting_text_cont))
+          (text))
         (setting_value_cont)
         (comment
           (text))
         (setting_value_cont
           (comment
             (text))
-          (setting_text_cont))))
+          (text))))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))
 
 ===========================================
 escaped sequences
@@ -130,23 +130,23 @@ esc\\ in keys \\= 1
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont
-          (setting_text_cont))))
+          (text))))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)
+        (text)
         (setting_value_cont
-          (setting_text_cont))))
+          (text))))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text))))
@@ -183,25 +183,25 @@ foo = bar
       (ERROR
         (setting_name))
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (ERROR
         (setting_name))
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text)
@@ -210,14 +210,14 @@ foo = bar
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (ERROR
     (text)
     (setting_name)

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -1,0 +1,73 @@
+================================================================================
+line continuation on setting values
+================================================================================
+
+[section]
+multi = foo? \
+bar ; not comment \
+ bay\s \
+baz
+multi2 =\
+still value \
+#
+# this is comment
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (section_name
+      (text))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)
+        (setting_value_cont
+          (setting_text))
+        (setting_value_cont
+          (setting_text))
+        (setting_value_cont
+          (setting_text))))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_value_cont
+          (setting_text))
+        (setting_value_cont
+          (setting_text)))))
+  (comment
+    (text)))
+
+===========================================
+escaped backslash
+===========================================
+
+[section]
+single = escaped backslash \\
+multi = foo \
+bar \\
+multi = esc before line cont \\\
+other esc seqs \t\t\ d
+
+--------------------------------------------
+
+(document
+  (section
+    (section_name
+      (text))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)
+        (setting_value_cont
+          (setting_text))))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)
+        (setting_value_cont
+          (setting_text))))))

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -5,24 +5,9 @@ line continuation on setting values
 [section]
 multi = foo? \
 bar ; not comment \
- bay\s \
-still=value
-
-multi2 =\
-cont value \
-#
-# atop is not comment
-
-legal = foo \
-\
-bar \
-\
-\
-end
-legal = foo \
-\
-
-# end of test
+[not section] \
+ can have space \
+still = value
 
 --------------------------------------------------------------------------------
 
@@ -35,42 +20,96 @@ legal = foo \
       (setting_value
         (setting_text)
         (setting_value_cont
-          (setting_text))
+          (setting_text_cont))
         (setting_value_cont
-          (setting_text))
+          (setting_text_cont))
         (setting_value_cont
-          (setting_text))))
+          (setting_text_cont))
+        (setting_value_cont
+          (setting_text_cont))))))
+
+================================================================================
+comments in continued lines
+================================================================================
+
+setting = value1 \
+# this line is comment
+; also comment
+value2 \
+  # comment with indent
+value3 
+
+--------------------------------------------------------------------------------
+
+(document
+  (unnamed_section
     (setting
       (setting_name)
       (setting_value
+        (setting_text)
         (setting_value_cont
-          (setting_text))
+          (comment
+            (text))
+          (comment
+            (text))
+          (setting_text_cont))
         (setting_value_cont
-          (setting_text))))
-    (comment
-      (text))
+          (comment
+            (text))
+          (setting_text_cont))))))
+
+================================================================================
+empty continued lines
+================================================================================
+
+setting = value1 \
+\
+value2 \
+\
+\
+value3 \
+# comment
+\
+; also comment
+value4 
+setting2 = ended next line \
+
+foo = 3
+
+--------------------------------------------------------------------------------
+
+(document
+  (unnamed_section
     (setting
       (setting_name)
       (setting_value
         (setting_text)
         (setting_value_cont)
         (setting_value_cont
-          (setting_text))
+          (setting_text_cont))
         (setting_value_cont)
         (setting_value_cont)
         (setting_value_cont
-          (setting_text))))
+          (setting_text_cont))
+        (setting_value_cont)
+        (comment
+          (text))
+        (setting_value_cont
+          (comment
+            (text))
+          (setting_text_cont))))
     (setting
       (setting_name)
       (setting_value
         (setting_text)
-        (setting_value_cont)
-        (setting_value_cont))))
-  (comment
-    (text)))
+        (setting_value_cont)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)))))
 
 ===========================================
-escaped backslash
+escaped sequences
 ===========================================
 
 [section]
@@ -78,7 +117,9 @@ single = escaped backslash \\
 multi = foo \
 bar \\
 multi = esc before line cont \\\
-other esc seqs \t\t\ d
+other esc seqs \t\ \ 
+esc\\ in keys \\= 1
+[esc seq\tin section\\]
 
 --------------------------------------------
 
@@ -95,16 +136,23 @@ other esc seqs \t\t\ d
       (setting_value
         (setting_text)
         (setting_value_cont
-          (setting_text))))
+          (setting_text_cont))))
     (setting
       (setting_name)
       (setting_value
         (setting_text)
         (setting_value_cont
-          (setting_text))))))
+          (setting_text_cont))))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text))))
+  (section
+    (section_name
+      (text))))
 
 ================================================================================
-no line continuation on setting names
+invalid line continuation locations
 ================================================================================
 
 [section]
@@ -115,6 +163,14 @@ illegal \\\
 name = 3
 legal escaped\t \\ name = 4
 legal \\= 5
+[illegal on \
+section]
+foo = bar
+
+[foo]
+bar = baz
+[illegal after section] \
+foo = bar
 
 --------------------------------------------------------------------------------
 
@@ -124,7 +180,8 @@ legal \\= 5
       (text))
     (setting
       (setting_name)
-      (ERROR)
+      (ERROR
+        (setting_name))
       (setting_value
         (setting_text)))
     (setting
@@ -133,7 +190,8 @@ legal \\= 5
         (setting_text)))
     (setting
       (setting_name)
-      (ERROR)
+      (ERROR
+        (setting_name))
       (setting_value
         (setting_text)))
     (setting
@@ -143,5 +201,24 @@ legal \\= 5
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
-
+        (setting_text))))
+  (section
+    (section_name
+      (text)
+      (ERROR
+        (setting_name)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text))))
+  (section
+    (section_name
+      (text))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text))))
+  (ERROR
+    (text)
+    (setting_name)
+    (setting_name)))

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -6,11 +6,23 @@ line continuation on setting values
 multi = foo? \
 bar ; not comment \
  bay\s \
-baz
+still=value
+
 multi2 =\
-still value \
+cont value \
 #
-# this is comment
+# atop is not comment
+
+legal = foo \
+\
+bar \
+\
+\
+end
+legal = foo \
+\
+
+# end of test
 
 --------------------------------------------------------------------------------
 
@@ -34,7 +46,26 @@ still value \
         (setting_value_cont
           (setting_text))
         (setting_value_cont
-          (setting_text)))))
+          (setting_text))))
+    (comment
+      (text))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)
+        (setting_value_cont)
+        (setting_value_cont
+          (setting_text))
+        (setting_value_cont)
+        (setting_value_cont)
+        (setting_value_cont
+          (setting_text))))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)
+        (setting_value_cont)
+        (setting_value_cont))))
   (comment
     (text)))
 

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -102,3 +102,46 @@ other esc seqs \t\t\ d
         (setting_text)
         (setting_value_cont
           (setting_text))))))
+
+================================================================================
+no line continuation on setting names
+================================================================================
+
+[section]
+illegal line cont\
+inuation = 1
+legal = 2
+illegal \\\
+name = 3
+legal escaped\t \\ name = 4
+legal \\= 5
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (section_name
+      (text))
+    (setting
+      (setting_name)
+      (ERROR)
+      (setting_value
+        (setting_text)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)))
+    (setting
+      (setting_name)
+      (ERROR)
+      (setting_value
+        (setting_text)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text)))))
+

--- a/test/corpus/line-cont.txt
+++ b/test/corpus/line-cont.txt
@@ -31,6 +31,7 @@ still = value
 ================================================================================
 comments in continued lines
 ================================================================================
+# see `man 7 systemd.syntax`.
 
 setting = value1 \
 # this line is comment
@@ -42,6 +43,8 @@ value3
 --------------------------------------------------------------------------------
 
 (document
+  (comment
+    (text))
   (unnamed_section
     (setting
       (setting_name)

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -174,10 +174,8 @@ only comments
 (document
   (comment
     (text))
-  (comment
-    (text))
-  (comment
-    (text)))
+  (comment)
+  (comment))
 
 ================================================================================
 mixed comments #5
@@ -202,8 +200,7 @@ key1=val1
 --------------------------------------------------------------------------------
 
 (document
-  (comment
-    (text))
+  (comment)
   (comment
     (text))
   (comment
@@ -368,9 +365,10 @@ c=d
 (document
   (comment
       (text))
-  (setting
-    (setting_name)
-    (setting_value))
+  (unnamed_section
+      (setting
+        (setting_name)
+        (setting_value)))
   (comment
       (text))
   (section

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -377,3 +377,32 @@ c=d
     (setting
       (setting_name)
       (setting_value))))
+
+================================================================================
+multi-line setting values
+================================================================================
+
+[section]
+multi = foo? \
+bar ; not comment \
+ bay\s \
+baz
+multi2 =\
+still value \
+#
+# this is comment
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (section_name
+      (text))
+    (setting
+      (setting_name)
+      (setting_value))
+    (setting
+      (setting_name)
+      (setting_value)))
+  (comment (text)))
+

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -14,7 +14,7 @@ foo = bar
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))
 
 ================================================================================
 setting value may be null/empty #9
@@ -41,7 +41,7 @@ setting-5 =
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name))
     (comment
@@ -49,7 +49,7 @@ setting-5 =
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)))
   (section
@@ -78,19 +78,19 @@ ignore all white space   =   my value
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))
 
 ================================================================================
 many sections, some empty
@@ -134,14 +134,14 @@ foo = bar
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text)))
@@ -151,11 +151,11 @@ foo = bar
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (comment
       (text))
     (comment
@@ -165,11 +165,11 @@ foo = bar
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (comment
     (text))
   (comment
@@ -228,7 +228,7 @@ key1=val1
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (comment
     (text))
   (section
@@ -241,7 +241,7 @@ key1=val1
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))
 
 ================================================================================
 one section (empty)
@@ -272,11 +272,11 @@ zim = -1>3 ; not-a-comment
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))
 
 ================================================================================
 invalid section
@@ -294,7 +294,7 @@ invalid section
     (setting
       (setting_name)
       (setting_value
-        (setting_text))
+        (text))
       ))
   )
 
@@ -338,11 +338,11 @@ output = json
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text))
@@ -351,18 +351,18 @@ output = json
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (comment
       (text))
     (comment
@@ -370,15 +370,15 @@ output = json
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))
+        (text)))
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (comment
     (text)))
 
@@ -400,7 +400,7 @@ c=d
     (setting
       (setting_name)
       (setting_value
-        (setting_text))))
+        (text))))
   (comment
     (text))
   (section
@@ -409,4 +409,4 @@ c=d
     (setting
       (setting_name)
       (setting_value
-        (setting_text)))))
+        (text)))))

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -13,7 +13,8 @@ foo = bar
       (text))
     (setting
       (setting_name)
-      (setting_value))))
+      (setting_value
+        (setting_text)))))
 
 ================================================================================
 setting value may be null/empty #9
@@ -39,14 +40,16 @@ setting-5 =
       (setting_name))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name))
     (comment
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)))
   (section
@@ -74,16 +77,20 @@ ignore all white space   =   my value
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))))
+      (setting_value
+        (setting_text)))))
 
 ================================================================================
 many sections, some empty
@@ -126,13 +133,15 @@ foo = bar
       (text))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (section
     (section_name
       (text)))
@@ -141,10 +150,12 @@ foo = bar
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (comment
       (text))
     (comment
@@ -153,10 +164,12 @@ foo = bar
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (comment
     (text))
   (comment
@@ -214,7 +227,8 @@ key1=val1
       (text))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (comment
     (text))
   (section
@@ -226,7 +240,8 @@ key1=val1
       (text))
     (setting
       (setting_name)
-      (setting_value))))
+      (setting_value
+        (setting_text)))))
 
 ================================================================================
 one section (empty)
@@ -256,10 +271,12 @@ zim = -1>3 ; not-a-comment
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))))
+      (setting_value
+        (setting_text)))))
 
 ================================================================================
 invalid section
@@ -270,11 +287,16 @@ invalid section
 --------------------------------------------------------------------------------
 
 (document
-  (ERROR
-    (text)
-    (UNEXPECTED 'a')
-    (UNEXPECTED 'b'))
-    (comment (text)))
+  (section
+    (section_name
+      (text)
+      (MISSING _eol))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text))
+      ))
+  )
 
 ================================================================================
 ~/.aws/config
@@ -315,10 +337,12 @@ output = json
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (section
     (section_name
       (text))
@@ -326,31 +350,38 @@ output = json
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (comment
       (text))
     (comment
       (text))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value))
+      (setting_value
+        (setting_text)))
     (setting
       (setting_name)
-      (setting_value)))
+      (setting_value
+        (setting_text))))
   (comment
     (text)))
+
 ================================================================================
 global-parameters
 ================================================================================
@@ -364,16 +395,18 @@ c=d
 
 (document
   (comment
-      (text))
+    (text))
   (unnamed_section
-      (setting
-        (setting_name)
-        (setting_value)))
+    (setting
+      (setting_name)
+      (setting_value
+        (setting_text))))
   (comment
-      (text))
+    (text))
   (section
     (section_name
       (text))
     (setting
       (setting_name)
-      (setting_value))))
+      (setting_value
+        (setting_text)))))

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -377,32 +377,3 @@ c=d
     (setting
       (setting_name)
       (setting_value))))
-
-================================================================================
-multi-line setting values
-================================================================================
-
-[section]
-multi = foo? \
-bar ; not comment \
- bay\s \
-baz
-multi2 =\
-still value \
-#
-# this is comment
-
---------------------------------------------------------------------------------
-
-(document
-  (section
-    (section_name
-      (text))
-    (setting
-      (setting_name)
-      (setting_value))
-    (setting
-      (setting_name)
-      (setting_value)))
-  (comment (text)))
-


### PR DESCRIPTION
Added support for line continuation using "\\" and its escaped sequence "\\\\".

Also contains:
1. a major refactor for `grammar.js` (but still keeping crucial patterns unchanged, e.g. `section_name` and `setting_name`);
2. make all non-root named rules have minimum width of 1;
    - "text" node is now optional under "comments" nodes.
5. added test for the new feature, in a separate test file.

implements #19